### PR TITLE
Authorize net test purchase

### DIFF
--- a/lib/gringotts.ex
+++ b/lib/gringotts.ex
@@ -2,9 +2,26 @@ defmodule Gringotts do
   @moduledoc ~S"""
   Gringotts is a payment gateway integration library supporting many gateway integrations.
   
-  Where the configuration for `Gringotts` must be in your application
-  environment, usually defined in your `config/config.exs`:
-      
+  ## Configuration
+  
+  The configuration for `Gringotts` must be in your application environment, 
+  usually defined in your `config/config.exs` and are **mandatory**:
+
+  **Global Configuration**
+  
+  The global configuration sets the library level configurations to interact with the gateway.
+  If the mode is not set then by 'default' the sandbox account is selected.
+
+  To integrate with the sandbox account set.
+      config :gringotts, :global_config,
+        mode: "test"
+  To integrate with the live account set.
+      config :gringotts, :global_config,
+        mode: "prod"
+
+  **Gateway Configuration**
+
+  The gateway level configurations are for fields related to a specific gateway. 
       config :Gringotts, Gringotts.Gateways.Stripe,
         adapter: Gringotts.Gateways.Stripe,
         api_key: "sk_test_vIX41hC0sdfBKrPWQerLuOMld",
@@ -64,12 +81,6 @@ defmodule Gringotts do
 
     > This is passed as is to the gateway and not modified, usually it comes back in the 
     response object intact.
-
-  ### Sandbox Account
-     To test the api with your sandbox or test account, options list should have the
-     following key value pair.
-
-     `[{mode: "test"}]`
   """
   
   import GenServer, only: [call: 2]

--- a/lib/gringotts.ex
+++ b/lib/gringotts.ex
@@ -64,6 +64,12 @@ defmodule Gringotts do
 
     > This is passed as is to the gateway and not modified, usually it comes back in the 
     response object intact.
+
+  ### Sandbox Account
+     To test the api with your sandbox or test account, options list should have the
+     following key value pair.
+
+     `[{mode: "test"}]`
   """
   
   import GenServer, only: [call: 2]

--- a/lib/gringotts.ex
+++ b/lib/gringotts.ex
@@ -14,10 +14,10 @@ defmodule Gringotts do
 
   To integrate with the sandbox account set.
       config :gringotts, :global_config,
-        mode: "test"
+        mode: :test
   To integrate with the live account set.
       config :gringotts, :global_config,
-        mode: "prod"
+        mode: :prod
 
   **Gateway Configuration**
 

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -568,8 +568,9 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   
   defp base_url(opts) do
     cond do
-      opts[:mode] == "test" -> @test_url
-      true -> @production_url
+      opts[:config][:mode] == "prod" -> @production_url
+      opts[:config][:mode] == "test" -> @test_url
+      true -> @test_url
     end  
   end
 

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -568,8 +568,8 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   
   defp base_url(opts) do
     cond do
-      opts[:config][:mode] == "prod" -> @production_url
-      opts[:config][:mode] == "test" -> @test_url
+      opts[:config][:mode] == :prod -> @production_url
+      opts[:config][:mode] == :test -> @test_url
       true -> @test_url
     end  
   end

--- a/lib/gringotts/worker.ex
+++ b/lib/gringotts/worker.ex
@@ -82,6 +82,8 @@ defmodule Gringotts.Worker do
   end
 
   defp set_gateway_and_config(request_gateway) do
-    { request_gateway, Application.get_env(:gringotts, request_gateway) }
+    global_config = Application.get_env(:gringotts, :global_config) || [mode: "test"]
+    gateway_config = Application.get_env(:gringotts, request_gateway)
+    {request_gateway, Keyword.merge(global_config, gateway_config)}
   end
 end

--- a/lib/gringotts/worker.ex
+++ b/lib/gringotts/worker.ex
@@ -82,7 +82,7 @@ defmodule Gringotts.Worker do
   end
 
   defp set_gateway_and_config(request_gateway) do
-    global_config = Application.get_env(:gringotts, :global_config) || [mode: "test"]
+    global_config = Application.get_env(:gringotts, :global_config) || [mode: :test]
     gateway_config = Application.get_env(:gringotts, request_gateway)
     {request_gateway, Keyword.merge(global_config, gateway_config)}
   end

--- a/test/gateways/monei_test.exs
+++ b/test/gateways/monei_test.exs
@@ -50,10 +50,12 @@ defmodule Gringotts.Gateways.MoneiTest do
   # A new Bypass instance is needed per test, so that we can do parallel tests
   setup do
     bypass = Bypass.open
-    auth = %{userId: "8a829417539edb400153c1eae83932ac",
-             password: "6XqRtMGS2N",
-             entityId: "8a829417539edb400153c1eae6de325e",
-             test_url: "http://localhost:#{bypass.port}"}
+    auth = %{
+      userId: "8a829417539edb400153c1eae83932ac",
+      password: "6XqRtMGS2N",
+      entityId: "8a829417539edb400153c1eae6de325e",
+      test_url: "http://localhost:#{bypass.port}"
+    }
     {:ok, bypass: bypass, auth: auth}
   end
 

--- a/test/mocks/authorize_net_mock.exs
+++ b/test/mocks/authorize_net_mock.exs
@@ -1,6 +1,61 @@
-  defmodule Gringotts.Gateways.AtuhtorizeNetMock do
+  defmodule Gringotts.Gateways.AuthorizeNetMock do
 
-    def successful_response do
-      
+    def successful_purchase_response do
+      {:ok,
+      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>C7HPT1</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>60036553096</transId><refTransID /><transHash>5D6782A03246EE3BAFABE8006E32DE97</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>",
+       headers: [{"Cache-Control", "private"},
+        {"Content-Type", "application/xml; charset=utf-8"},
+        {"X-OPNET-Transaction-Trace",
+         "a2_b6b84b43-d399-4dde-bc12-fb1f8ccf4b27-51156-13182173"},
+        {"Access-Control-Allow-Origin", "*"},
+        {"Access-Control-Allow-Methods", "PUT,OPTIONS,POST,GET"},
+        {"Access-Control-Allow-Headers",
+         "x-requested-with,cache-control,content-type,origin,method,SOAPAction"},
+        {"Access-Control-Allow-Credentials", "true"}, {"X-Cnection", "close"},
+        {"Content-Length", "908"}, {"Date", "Thu, 21 Dec 2017 09:29:12 GMT"},
+        {"Connection", "keep-alive"}],
+       request_url: "https://apitest.authorize.net/xml/v1/request.api",
+       status_code: 200}}
+    end
+
+    def bad_card_purchase_response do
+      {:ok,
+      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><ErrorResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XXXXX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>",
+       headers: [{"Cache-Control", "private"},
+        {"Content-Type", "application/xml; charset=utf-8"},
+        {"X-OPNET-Transaction-Trace",
+         "a2_f2f80544-1a98-4ad7-989b-8d267ebf5043-56152-10066531"},
+        {"Access-Control-Allow-Origin", "*"},
+        {"Access-Control-Allow-Methods", "PUT,OPTIONS,POST,GET"},
+        {"Access-Control-Allow-Headers",
+         "x-requested-with,cache-control,content-type,origin,method,SOAPAction"},
+        {"Access-Control-Allow-Credentials", "true"}, {"X-Cnection", "close"},
+        {"Content-Length", "514"}, {"Date", "Thu, 21 Dec 2017 09:35:45 GMT"},
+        {"Connection", "keep-alive"}],
+       request_url: "https://apitest.authorize.net/xml/v1/request.api",
+       status_code: 200}}
+    end
+
+    def bad_amount_purchase_response do
+      {:ok,
+      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>5</errorCode><errorText>A valid amount is required.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>",
+       headers: [{"Cache-Control", "private"},
+        {"Content-Type", "application/xml; charset=utf-8"},
+        {"X-OPNET-Transaction-Trace",
+         "a2_b6b84b43-d399-4dde-bc12-fb1f8ccf4b27-51156-13187900"},
+        {"Access-Control-Allow-Origin", "*"},
+        {"Access-Control-Allow-Methods", "PUT,OPTIONS,POST,GET"},
+        {"Access-Control-Allow-Headers",
+         "x-requested-with,cache-control,content-type,origin,method,SOAPAction"},
+        {"Access-Control-Allow-Credentials", "true"}, {"X-Cnection", "close"},
+        {"Content-Length", "867"}, {"Date", "Thu, 21 Dec 2017 09:44:33 GMT"},
+        {"Connection", "keep-alive"}],
+       request_url: "https://apitest.authorize.net/xml/v1/request.api",
+       status_code: 200}}
+    end
+
+    def network_error_response do
+      body = "no response error"
+      {:error, %{body: body, status_code: 500}}
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,2 @@
 ExUnit.start(trace: true, exclude: [integration: true])
 Application.ensure_all_started(:bypass)
-


### PR DESCRIPTION
Fix for #31 

1. **Setting a global  `config`  for 'prod' or 'test' mode.**
    This is a new feature provided as a `:global_config` for the lib to set the url for making requests to the 
    gateway.  The configuration is done in the application as follows for test: 
     ``` elixir
        config :gringotts, :global_config,
          mode: :test
     ```
    and for prod
     ```elixir
      config :gringotts, :global_config,
        mode: :prod
     ```

    It would be available as following in `opts[:config: [mode: :test ]]`. Made necessary checks on this to 
    change the api for making calls to the gateway.
2. **Added test for purchase method for authorize net payment gateway using mock.**
    The new strategy is to use `mock` library for testing the gateways. The strategy was devised keeping 
    in mind the fact that any fields required in the test should be limited to the scope. Nothing should be 
    passed from the test to the gateway module. With `bypass` the `localhost` url needs to be passed to 
    the module and in the absence of alternate strategy the decision was made.

3. **Added doc in gringotts.ex for configuration.**
   Made changes to "gringotts" docs to include the configuration fields and the way they should be set for  
   accessing the library `global configurations` and `gateway specific configurations`.  