### PR TITLE
Creditcard docs

### DIFF
--- a/lib/gringotts/credit_card.ex
+++ b/lib/gringotts/credit_card.ex
@@ -1,16 +1,47 @@
 defmodule Gringotts.CreditCard do
-  @moduledoc ~S"""
-  CreditCard module defines the struct for the credit cards. 
-
-  It mostly has such as:-
-    * `number`: Credit card number
-    * `month`: Expiry month
-    * `year`: Expiration year
-    * `first_name`: First name of the card holder
-    * `last_name`: Last of the card holder
-    * `verification_code`: 3/4 digit code at the back of the card
-    * `brand`: VISA/MASTERCARD/MAESTRO/RUPAY etc.
+  @moduledoc """
+  Defines a `Struct` for (credit) cards and some utilities.
   """
 
   defstruct [:number, :month, :year, :first_name, :last_name, :verification_code, :brand]
+  @typedoc """
+  Represents a Credit Card.
+
+  | Field               | Type       | Description                                  |
+  | -----               | ----       | -----------                                  |
+  | `number`            | `string`   | The card number.                             |
+  | `month`             | `integer`  | Month of expiry (a number in the `1..12`\
+                                       range).                                      |
+  | `year`              | `integer`  | Year of expiry.                              |
+  | `first_name`        | `string`   | First name of the card holder (as on card).  |
+  | `last_name`         | `string`   | Last name of the card holder (as on card).   |
+  | `verification_code` | `string`   | The [Card Verification Code][cvc], usually\
+                                       a 3-4 digit number on the back of the card.  |
+  | `brand`             | `string`   | The brand name of the card network (in\
+                                       some cases also the card issuer) in\
+                                       UPPERCASE. Some popular card networks\
+                                       are [Visa][visa], [MasterCard][mc],\
+                                       [Maestro][mo], [Diner's Club][dc] etc.       |
+
+  [cvc]: https://en.wikipedia.org/wiki/Card_security_code
+  [visa]: https://usa.visa.com
+  [mc]: https://www.mastercard.us/en-us.html
+  [mo]: http://www.maestrocard.com/gateway/index.html
+  [dc]: http://www.dinersclub.com/
+  """
+  @type t :: %__MODULE__{number: String.t,
+                         month: 1..12,
+                         year: non_neg_integer,
+                         first_name: String.t,
+                         last_name: String.t,
+                         verification_code: String.t,
+                         brand: String.t}
+
+  @doc """
+  Returns the full name of the card holder.
+
+  Joins `first_name` and `last_name` with a space in between.
+  """
+  @spec full_name(t) :: String.t
+  def full_name(card), do: "#{card.first_name} #{card.last_name}"
 end

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -91,7 +91,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       card = %CreditCard{number: "5424000000000015", year: 2020, month: 12, verification_code: "999"} 
       amount = 5
   """
-  @spec purchase(Float, CreditCard, Keyword) :: Tuple
+  @spec purchase(Float, CreditCard.t, Keyword) :: Tuple
   def purchase(amount, payment, opts) do
     request_data = add_auth_purchase(amount, payment, opts, @transaction_type[:purchase])
     response_data = commit(:post, request_data, opts)
@@ -128,7 +128,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       card = %CreditCard{number: "5424000000000015", year: 2020, month: 12, verification_code: "999"} 
       amount = 5
   """
-  @spec authorize(Float, CreditCard, Keyword) :: Tuple
+  @spec authorize(Float, CreditCard.t, Keyword) :: Tuple
   def authorize(amount, payment, opts) do
     request_data = add_auth_purchase(amount, payment, opts, @transaction_type[:authorize])
     response_data = commit(:post, request_data, opts)
@@ -233,7 +233,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
       card = %CreditCard{number: "5424000000000015", year: 2020, month: 12, verification_code: "999"}
   """
-  @spec store(CreditCard, Keyword) :: Tuple
+  @spec store(CreditCard.t, Keyword) :: Tuple
   def store(card, opts) do
     request_data = cond  do
       opts[:customer_profile_id] -> create_customer_payment_profile(card, opts) |> generate 

--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -52,7 +52,7 @@ defmodule Gringotts.Gateways.Cams do
       
       iex> Gringotts.purchase(:payment_worker, Gringotts.Gateways.Cams, money, payment, options)
   """
-  @spec purchase(number, CreditCard, Keyword) :: Response
+  @spec purchase(number, CreditCard.t, Keyword) :: Response
   def purchase(money, payment, options) do
     post = []
           |> add_invoice(money, options)
@@ -88,7 +88,7 @@ defmodule Gringotts.Gateways.Cams do
       
       iex> Gringotts.authorize(:payment_worker, Gringotts.Gateways.Cams, money, payment, options)
   """
-  @spec authorize(number, CreditCard, Keyword) :: Response
+  @spec authorize(number, CreditCard.t, Keyword) :: Response
   def authorize(money, payment, options) do
     post = []
       |> add_invoice(money, options)

--- a/lib/gringotts/gateways/paymill.ex
+++ b/lib/gringotts/gateways/paymill.ex
@@ -57,7 +57,7 @@ defmodule Gringotts.Gateways.Paymill do
 
       iex> Gringotts.authorize(:payment_worker, Gringotts.Gateways.Paymill, amount, card, options)
   """
-  @spec authorize(number, String.t | CreditCard, Keyword) :: {:ok | :error, Response}
+  @spec authorize(number, String.t | CreditCard.t, Keyword) :: {:ok | :error, Response}
   def authorize(amount, card_or_token, options) do
     Keyword.put(options, :money, amount)
     action_with_token(:authorize, amount, card_or_token, options)
@@ -82,7 +82,7 @@ defmodule Gringotts.Gateways.Paymill do
 
       iex> Gringotts.purchase(:payment_worker, Gringotts.Gateways.Paymill, amount, card, options)
   """
-  @spec purchase(number, CreditCard, Keyword) :: {:ok | :error, Response}
+  @spec purchase(number, CreditCard.t, Keyword) :: {:ok | :error, Response}
   def purchase(amount, card, options) do
     Keyword.put(options, :money, amount)
     action_with_token(:purchase, amount, card, options)
@@ -138,7 +138,7 @@ defmodule Gringotts.Gateways.Paymill do
     commit(:post, "transactions", post, options)
   end
 
-  @spec save_card(CreditCard, Keyword) :: Response
+  @spec save_card(CreditCard.t, Keyword) :: Response
   defp save_card(card, options) do
     {:ok, %HTTPoison.Response{body: response}} = HTTPoison.get(
         get_save_card_url(),
@@ -148,7 +148,7 @@ defmodule Gringotts.Gateways.Paymill do
      parse_card_response(response)
   end
 
-  @spec save(CreditCard, Keyword) :: Response
+  @spec save(CreditCard.t, Keyword) :: Response
   defp save(card, options) do
     save_card(card, options)
   end

--- a/lib/gringotts/gateways/wire_card.ex
+++ b/lib/gringotts/gateways/wire_card.ex
@@ -77,7 +77,7 @@ defmodule Gringotts.Gateways.WireCard do
       test: true
     ] 
   """
-  @spec authorize(Integer | Float, CreditCard | String.t, Keyword) :: { :ok, Map }
+  @spec authorize(Integer | Float, CreditCard.t | String.t, Keyword) :: { :ok, Map }
   def authorize(money, payment_method, options \\ [])
 
   def authorize(money, %CreditCard{} = creditcard, options) do
@@ -183,7 +183,7 @@ defmodule Gringotts.Gateways.WireCard do
     the returned authorization/GuWID usable in later transactions
     with +options[:recurring] = 'Repeated'+.
   """
-  @spec store(CreditCard, Keyword) :: { :ok, Map }
+  @spec store(CreditCard.t, Keyword) :: { :ok, Map }
   def store(%CreditCard{} = creditcard, options \\ []) do
     options = options 
                 |> Keyword.put(:credit_card, creditcard) 


### PR DESCRIPTION
# Why `CreditCard.t`?
If you read up on how to document Structs, you'll realise that `CreditCard`, (the module) should not be used as a "type" -- because it is a module, just a bunch of functions. This is related to the confusion between `String` and `String.t`.

Composite types must be defined using `@type`. This helps static analysers like Dialyser to actually perform type-checking.

## Real World example
In the excellent [swoosh library](https://github.com/swoosh/swoosh/search?utf8=%E2%9C%93&q=type+t+%3A%3A+%25__MODULE__%7Btype&type=).

References:
https://www.reddit.com/r/elixir/comments/4v2ss2/help_me_understand_types_in_documentation_specs/
http://elixir-recipes.github.io/types/type-checking/
https://hexdocs.pm/elixir/typespecs.html#user-defined-types
https://stackoverflow.com/questions/29977776/what-does-type-t-module-mean-in-elixir

# Other
Notice that,
* `:year` and `:month` are **integers**!
* the typespecs now show `Gringotts.CreditCard.t`, (which is clickable, unlike before!) instead of `Gringotts.CreditCard`