### PR TITLE
Paymill: Mock tests

### DIFF
--- a/lib/gringotts/gateways/paymill.ex
+++ b/lib/gringotts/gateways/paymill.ex
@@ -341,6 +341,11 @@ defmodule Gringotts.Gateways.Paymill do
       |> set_params(body)
       |> handle_opts()
     end
+    def parse({:ok, %HTTPoison.Response{body: body, status_code: 403}}) do
+      body = Poison.decode!(body)
+      [status_code: 403, success: false]
+      |> parse_body(body)
+    end
     def parse(({:ok, %HTTPoison.Response{body: body, status_code: 409}})) do
       body = Poison.decode!(body)
       [status_code: 409, success: false]
@@ -355,7 +360,10 @@ defmodule Gringotts.Gateways.Paymill do
 
     defp set_success(opts, %{"transaction" => %{"response_code" => 20_000}}) do
       opts ++ [success: true]
-    ends
+    end
+    defp set_success(opts, %{"response_code" => 20_000}) do
+      opts ++ [success: true]
+    end
 
     defp handle_error(opts, %{"error" => %{"messages" => messages}}) do
       [{_, msg} | _] = Map.to_list(messages)

--- a/lib/gringotts/gateways/paymill.ex
+++ b/lib/gringotts/gateways/paymill.ex
@@ -92,6 +92,7 @@ defmodule Gringotts.Gateways.Paymill do
   alias Gringotts.Gateways.Paymill.ResponseHandler, as: ResponseParser
 
   @live_url "https://api.paymill.com/v2.1/"
+  @save_card_url "https://test-token.paymill.com/"
   @headers [{"Content-Type", "application/x-www-form-urlencoded"}]
 
   @doc """
@@ -135,7 +136,8 @@ defmodule Gringotts.Gateways.Paymill do
 
   PAYMILL allows partial captures and unlike many other gateways, and releases
   any remaining amount back to the payment source.
-  > Thus, the same pre-authorisation ID cannot be used to perform multiple captures.
+  > Thus, the same pre-authorisation ID **cannot** be used to perform multiple
+    captures.
 
   ## Example
 
@@ -164,8 +166,8 @@ defmodule Gringotts.Gateways.Paymill do
 
   ## Example
 
-  The following example shows how one would process a payment worth €42 in one-shot,
-  without (pre) authorization.
+  The following example shows how one would process a payment worth €42 in
+  one-shot, without (pre) authorization.
 
   ```
   iex> amount = %{value: Decimal.new(42), currency: "EUR"}
@@ -251,9 +253,8 @@ defmodule Gringotts.Gateways.Paymill do
 
   @spec save_card(CreditCard.t, keyword) :: Response
   defp save_card(card, options) do
-    {:ok, %HTTPoison.Response{body: response}} =
-      HTTPoison.get(
-        get_save_card_url(),
+    {:ok, %HTTPoison.Response{body: response}} = HTTPoison.get(
+        @save_card_url,
         get_headers(options),
         params: get_save_card_params(card, options)
       )
@@ -307,8 +308,6 @@ defmodule Gringotts.Gateways.Paymill do
     [{"Authorization", "Basic #{Base.encode64(get_config(:private_key, options))}"}]
   end
 
-  defp get_save_card_url(), do: "https://test-token.paymill.com/"
-
   defp parse_card_response(response) do
     response
     |> String.replace(~r/jsonPFunction\(/, "")
@@ -322,8 +321,8 @@ defmodule Gringotts.Gateways.Paymill do
 
   defp commit(method, action, parameters, options) do
     method
-    |> HTTPoison.request(@live_url <> action, {:form, parameters}, get_headers(options), [])
-    |> ResponseParser.parse()
+    |> HTTPoison.request(@live_url <> action, {:form, parameters}, get_headers(options))
+    |> ResponseParser.parse
   end
 
   defp get_config(key, options) do
@@ -435,13 +434,12 @@ defmodule Gringotts.Gateways.Paymill do
 
     def parse({:ok, %HTTPoison.Response{body: body, status_code: 200}}) do
       body = Poison.decode!(body)
-      [status_code: 200]
-      |> parse_body(body)
+      parse_body([status_code: 200], body)
     end
-
-    def parse({:ok, %HTTPoison.Response{body: body, status_code: 400}}) do
+    
+    def parse({:ok, %HTTPoison.Response{body: body, status_code: status_code}}) when status_code in [400, 404, 409] do
       body = Poison.decode!(body)
-      [status_code: 400, success: false]
+      [status_code: status_code, success: false]
       |> set_params(body)
       |> handle_error(body)
       |> handle_opts
@@ -459,14 +457,11 @@ defmodule Gringotts.Gateways.Paymill do
       [status_code: 403, success: false]
       |> parse_body(body)
     end
-    def parse(({:ok, %HTTPoison.Response{body: body, status_code: 409}})) do
-      body = Poison.decode!(body)
-      [status_code: 409, success: false]
-      |> set_params(body)
-      |> handle_error(body)
-      |> handle_opts
-    end
 
+    def parse({:error, %HTTPoison.Error{} = error}) do
+      {:error, Response.error(error_code: error.id, message: "HTTPoison says '#{error.reason}'.")}
+    end
+      
     defp set_success(opts, %{"error" => error}) do
       opts ++ [message: error, success: false]
     end

--- a/lib/gringotts/gateways/paymill.ex
+++ b/lib/gringotts/gateways/paymill.ex
@@ -262,7 +262,7 @@ defmodule Gringotts.Gateways.Paymill do
 
   @doc false
   @spec authorize_with_token(Money.t(), String.t(), keyword) :: term
-  defp authorize_with_token(money, card_token, options) do
+  def authorize_with_token(money, card_token, options) do
     post = amount_params(money) ++ [token: card_token]
 
     commit(:post, "preauthorizations", post, options)
@@ -270,7 +270,7 @@ defmodule Gringotts.Gateways.Paymill do
 
   @doc false
   @spec purchase_with_token(Money.t(), String.t(), keyword) :: term
-  defp purchase_with_token(money, card_token, options) do
+  def purchase_with_token(money, card_token, options) do
     post = amount_params(money) ++ [token: card_token]
 
     commit(:post, "transactions", post, options)

--- a/lib/gringotts/gateways/paymill.ex
+++ b/lib/gringotts/gateways/paymill.ex
@@ -119,6 +119,13 @@ defmodule Gringotts.Gateways.Paymill do
     commit(:delete, "preauthorizations/#{authorization}", [], options)
   end
 
+  @spec refund(number, String.t, Keyword) :: {:ok | :error, Response}
+  def refund(amount, authorization, options) do
+    post = [amount: amount]
+
+    commit(:post, "refunds/#{authorization}", post, options)
+  end
+
   @doc false
   @spec authorize_with_token(number, String.t(), Keyword) :: term
   def authorize_with_token(money, card_token, options) do

--- a/test/gateways/paymill_test.exs
+++ b/test/gateways/paymill_test.exs
@@ -158,9 +158,32 @@ defmodule Gringotts.Gateways.PaymillTest do
   end
 
   describe "void/2" do
+
     test "with valid preauth token" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body, _headers, _opts) ->
+      MockResponse.successful_void end] do
+
+        {:ok, response} = Paymill.void("preauth_028b0d40a6465099a774", @options)
+
+        assert response.success
+        assert response.status_code == 200
+        assert response.error_code == 50810
+        assert response.message == "Authorisation has been voided"
+      end
     end
+
     test "with invalid preauth token" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body, _headers, _opts) ->
+      MockResponse.void_with_invalid_auth_token end] do
+
+        {:error, response} = Paymill.void("preauth_028b0d40a6465099a123", @options)
+
+        refute response.success
+        assert response.status_code == 404
+        assert response.message == "Preauthorization was not found"
+      end
     end
   end
 

--- a/test/gateways/paymill_test.exs
+++ b/test/gateways/paymill_test.exs
@@ -126,12 +126,35 @@ defmodule Gringotts.Gateways.PaymillTest do
   end
 
   describe "purchase/2" do
+
     test "with valid token" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body, _headers, _opts) ->
+      MockResponse.successful_purchase end] do
+
+        {:ok, response} = Paymill.purchase(100, "tok_59f35a89e96dee1ceb6b437317be", @options)
+
+        assert response.success
+        assert response.status_code == 200
+        assert response.error_code == 20000
+        assert response.message == "Operation successful"
+      end
     end
+
     test "with invalid token" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body, _headers, _opts) ->
+      MockResponse.purchase_with_invalid_card_token end] do
+
+        {:error, response} = Paymill.purchase(100, "tok_59f35a89e96dee1ceb6b437317be", @options)
+
+        refute response.success
+        assert response.status_code == 403
+        assert response.error_code == 40102
+        assert response.message == "Card expired or not yet valid"
+      end
     end
-    test "with already existing payments" do
-    end
+
   end
 
   describe "void/2" do

--- a/test/gateways/paymill_test.exs
+++ b/test/gateways/paymill_test.exs
@@ -1,8 +1,10 @@
 defmodule Gringotts.Gateways.PaymillTest do
   use ExUnit.Case, async: false
 
+  Code.require_file "../mocks/paymill_mock.exs", __DIR__
   alias Gringotts.{CreditCard, Response}
   alias Gringotts.Gateways.Paymill
+  alias Gringotts.Gateways.PaymillMock, as: MockResponse
 
   import Mock
 
@@ -10,15 +12,6 @@ defmodule Gringotts.Gateways.PaymillTest do
     first_name: "Sagar",
     last_name: "Karwande",
     number: "4111111111111111",
-    month: 12,
-    year: 2018,
-    verification_code: 123
-  }
-
-  @invalid_card %CreditCard{
-    first_name: "Sagar",
-    last_name: "Karwande",
-    number: "5105105105105100",
     month: 12,
     year: 2018,
     verification_code: 123
@@ -32,28 +25,61 @@ defmodule Gringotts.Gateways.PaymillTest do
   ]
 
   describe "authorize/3" do
-    test "with valid card details" do
+
+    test "with valid card token" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body,_headers, _opts) ->
+      MockResponse.successful_authorize end] do
+
+        {:ok, response} = Paymill.authorize(100, "tok_6864ab6cce1444833ede76077ed0", @options)
+
+        assert response.success
+        assert response.status_code == 200
+        assert response.error_code == 20000
+      end
     end
-    test "with invalid cvv details" do
+
+    test "with invalid cvv" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body,_headers, _opts) ->
+      MockResponse.authorize_invalid_cvv end] do
+
+        {:error, response} = Paymill.authorize(100, "tok_40101_23f20b1cebf9f4eb50d5e0", @options)
+
+        refute response.success
+        assert response.status_code == 200
+        assert response.error_code == 50800
+        assert response.message == "Preauthorisation failed"
+      end
     end
+
     test "with invalid card token" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body,_headers, _opts) ->
+      MockResponse.authorize_invalid_card_token end] do
+
+        {:error, response} = Paymill.authorize(100, "tok_123", @options)
+
+        refute response.success
+        assert response.status_code == 400
+        assert response.message == "'tok_123' does not match against pattern '/^[a-zA-Z0-9_]{32}$/'"
+      end
     end
-    test "with blacklisted card" do
-    end
-    test "with blacklisted account" do
-    end
-    test "with inlid authorization" do
-    end
+
     test "with currency or amount mismatch" do
+      with_mock HTTPoison,
+      [request: fn(_method, _url, _body,_headers, _opts) ->
+      MockResponse.authorize_invalid_currency end] do
+
+        invalid_opts = @options ++ [currency: "ABC"]
+        {:error, response} = Paymill.authorize(100, "tok_123", invalid_opts)
+
+        refute response.success
+        assert response.status_code == 400
+        assert response.message == "'ABC' was not found in the haystack"
+      end
     end
-    test "with card restricted by bank" do
-    end
-    test "with duplicate transaction" do
-    end
-    test "with blacklisted ip" do
-    end
-    test "with missing parameters" do
-    end
+
   end
 
   describe "capture/3" do

--- a/test/gateways/paymill_test.exs
+++ b/test/gateways/paymill_test.exs
@@ -1,0 +1,96 @@
+defmodule Gringotts.Gateways.PaymillTest do
+  use ExUnit.Case, async: false
+
+  alias Gringotts.{CreditCard, Response}
+  alias Gringotts.Gateways.Paymill
+
+  import Mock
+
+  @valid_card %CreditCard{
+    first_name: "Sagar",
+    last_name: "Karwande",
+    number: "4111111111111111",
+    month: 12,
+    year: 2018,
+    verification_code: 123
+  }
+
+  @invalid_card %CreditCard{
+    first_name: "Sagar",
+    last_name: "Karwande",
+    number: "5105105105105100",
+    month: 12,
+    year: 2018,
+    verification_code: 123
+  }
+
+  @options [
+    config: [
+      private_key: "8f16b021d4fb1f8d9263cbe346f32688",
+      public_key: "72294854039fcf7fd55eaeeb594577e7"
+    ]
+  ]
+
+  describe "authorize/3" do
+    test "with valid card details" do
+    end
+    test "with invalid cvv details" do
+    end
+    test "with invalid card token" do
+    end
+    test "with blacklisted card" do
+    end
+    test "with blacklisted account" do
+    end
+    test "with inlid authorization" do
+    end
+    test "with currency or amount mismatch" do
+    end
+    test "with card restricted by bank" do
+    end
+    test "with duplicate transaction" do
+    end
+    test "with blacklisted ip" do
+    end
+    test "with missing parameters" do
+    end
+  end
+
+  describe "capture/3" do
+    test "with valid preauth token" do
+    end
+    test "with already used preauth token" do
+    end
+    test "with invalid preauth token" do
+    end
+    test "with missing parameters" do
+    end
+  end
+
+  describe "purchase/2" do
+    test "with valid token" do
+    end
+    test "with invalid token" do
+    end
+    test "with already existing payments" do
+    end
+  end
+
+  describe "void/2" do
+    test "with valid preauth token" do
+    end
+    test "with invalid preauth token" do
+    end
+  end
+
+  describe "refund/3" do
+    test "with valid transaction token" do
+    end
+    test "with invalid transaction token" do
+    end
+    test "with hight amount than the transaction amount" do
+    end
+    test "with partial amount" do
+    end
+  end
+end

--- a/test/gateways/paymill_test.exs
+++ b/test/gateways/paymill_test.exs
@@ -35,7 +35,7 @@ defmodule Gringotts.Gateways.PaymillTest do
 
         assert response.success
         assert response.status_code == 200
-        assert response.error_code == 20000
+        assert response.error_code == 20_000
       end
     end
 
@@ -48,7 +48,7 @@ defmodule Gringotts.Gateways.PaymillTest do
 
         refute response.success
         assert response.status_code == 200
-        assert response.error_code == 50800
+        assert response.error_code == 50_800
         assert response.message == "Preauthorisation failed"
       end
     end
@@ -93,7 +93,7 @@ defmodule Gringotts.Gateways.PaymillTest do
 
         assert response.success
         assert response.status_code == 200
-        assert response.error_code == 20000
+        assert response.error_code == 20_000
       end
     end
 
@@ -136,7 +136,7 @@ defmodule Gringotts.Gateways.PaymillTest do
 
         assert response.success
         assert response.status_code == 200
-        assert response.error_code == 20000
+        assert response.error_code == 20_000
         assert response.message == "Operation successful"
       end
     end
@@ -150,7 +150,7 @@ defmodule Gringotts.Gateways.PaymillTest do
 
         refute response.success
         assert response.status_code == 403
-        assert response.error_code == 40102
+        assert response.error_code == 40_102
         assert response.message == "Card expired or not yet valid"
       end
     end
@@ -168,7 +168,7 @@ defmodule Gringotts.Gateways.PaymillTest do
 
         assert response.success
         assert response.status_code == 200
-        assert response.error_code == 50810
+        assert response.error_code == 50_810
         assert response.message == "Authorisation has been voided"
       end
     end

--- a/test/mocks/paymill_mock.exs
+++ b/test/mocks/paymill_mock.exs
@@ -44,4 +44,16 @@ defmodule Gringotts.Gateways.PaymillMock do
      request_url: "https://api.paymill.com/v2.1/transactions",
      status_code: 404}}
   end
+
+  def successful_purchase() do
+    {:ok, %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514400803,\"status\":\"closed\",\"short_id\":\"0000.9999.0000\",\"response_code\":20000,\"refunds\":null,\"preauthorization\":null,\"payment\":{\"updated_at\":1514400802,\"type\":\"creditcard\",\"last4\":\"1111\",\"is_usable_for_preauthorization\":true,\"is_recurring\":true,\"id\":\"pay_9a09b497432463b3a6ee1ad1\",\"expire_year\":\"2018\",\"expire_month\":\"12\",\"created_at\":1514400802,\"country\":\"DE\",\"client\":\"client_75b88daa13b3d547accd\",\"card_type\":\"visa\",\"card_holder\":\"Sagar Karwande\",\"app_id\":null},\"origin_amount\":100,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":true,\"is_markable_as_fraud\":true,\"is_fraud\":false,\"invoices\":[],\"id\":\"tran_9d4db278fbf8ef2e997ef42c0a55\",\"fees\":[],\"description\":\"\",\"currency\":\"EUR\",\"created_at\":1514400802,\"client\":{\"updated_at\":1514400802,\"subscription\":null,\"payment\":[\"pay_9a09b497432463b3a6ee1ad1\"],\"id\":\"client_75b88daa13b3d547accd\",\"email\":null,\"description\":null,\"created_at\":1514400802,\"app_id\":null},\"app_id\":null,\"amount\":100}}",
+      request_url: "https://api.paymill.com/v2.1/transactions",
+      status_code: 200}}
+  end
+
+  def purchase_with_invalid_card_token do
+    {:ok, %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514401924,\"status\":\"failed\",\"short_id\":null,\"response_code\":40102,\"refunds\":null,\"preauthorization\":null,\"payment\":{\"updated_at\":1514401923,\"type\":\"creditcard\",\"last4\":\"\",\"is_usable_for_preauthorization\":true,\"is_recurring\":true,\"id\":\"pay_0e39722b8afa3be3beeaa372\",\"expire_year\":\"\",\"expire_month\":\"\",\"created_at\":1514401923,\"country\":null,\"client\":\"client_51998977a73051f2b0da\",\"card_type\":null,\"card_holder\":\"\",\"app_id\":null},\"origin_amount\":100,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":false,\"is_markable_as_fraud\":true,\"is_fraud\":false,\"invoices\":[],\"id\":\"tran_3a6cc404cdb1c26065977d988ecd\",\"fees\":[],\"description\":\"\",\"currency\":\"EUR\",\"created_at\":1514401924,\"client\":{\"updated_at\":1514401923,\"subscription\":null,\"payment\":[\"pay_0e39722b8afa3be3beeaa372\"],\"id\":\"client_51998977a73051f2b0da\",\"email\":null,\"description\":null,\"created_at\":1514401923,\"app_id\":null},\"app_id\":null,\"amount\":100}}",
+      request_url: "https://api.paymill.com/v2.1/transactions",
+      status_code: 403}}
+  end
 end

--- a/test/mocks/paymill_mock.exs
+++ b/test/mocks/paymill_mock.exs
@@ -56,4 +56,16 @@ defmodule Gringotts.Gateways.PaymillMock do
       request_url: "https://api.paymill.com/v2.1/transactions",
       status_code: 403}}
   end
+
+  def successful_void do
+    {:ok, %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514405187,\"transaction\":{\"updated_at\":1514405187,\"status\":\"failed\",\"short_id\":null,\"response_code\":50810,\"refunds\":null,\"preauthorization\":\"preauth_028b0d40a6465099a774\",\"payment\":\"pay_d9eef5928b69760cd60c4784\",\"origin_amount\":200,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":false,\"is_markable_as_fraud\":true,\"is_fraud\":false,\"invoices\":[],\"id\":\"tran_2b8f2196ba52cc9c7e56d86d5bd4\",\"fees\":[],\"description\":null,\"currency\":\"INR\",\"created_at\":1514405146,\"client\":\"client_436f5667c0835f3adf2c\",\"app_id\":null,\"amount\":200},\"status\":\"deleted\",\"payment\":{\"updated_at\":1514396441,\"type\":\"creditcard\",\"last4\":\"1111\",\"is_usable_for_preauthorization\":true,\"is_recurring\":true,\"id\":\"pay_d9eef5928b69760cd60c4784\",\"expire_year\":\"2020\",\"expire_month\":\"3\",\"created_at\":1514396441,\"country\":\"DE\",\"client\":\"client_436f5667c0835f3adf2c\",\"card_type\":\"visa\",\"card_holder\":\"Sagar Karwande\",\"app_id\":null},\"livemode\":false,\"id\":\"preauth_028b0d40a6465099a774\",\"description\":null,\"currency\":\"INR\",\"created_at\":1514405146,\"client\":{\"updated_at\":1514396441,\"subscription\":null,\"payment\":[\"pay_d9eef5928b69760cd60c4784\"],\"id\":\"client_436f5667c0835f3adf2c\",\"email\":null,\"description\":null,\"created_at\":1514396441,\"app_id\":null},\"app_id\":null,\"amount\":\"200\"}}",
+      request_url: "https://api.paymill.com/v2.1/preauthorizations/preauth_028b0d40a6465099a774",
+      status_code: 200}}
+  end
+
+  def void_with_invalid_auth_token do
+    {:ok, %HTTPoison.Response{body: "{\"exception\":\"preauthorization_not_found\",\"error\":\"Preauthorization was not found\"}",
+      request_url: "https://api.paymill.com/v2.1/preauthorizations/preauth_028b0d40a6465099a123",
+      status_code: 404}}
+  end
 end

--- a/test/mocks/paymill_mock.exs
+++ b/test/mocks/paymill_mock.exs
@@ -68,4 +68,22 @@ defmodule Gringotts.Gateways.PaymillMock do
       request_url: "https://api.paymill.com/v2.1/preauthorizations/preauth_028b0d40a6465099a123",
       status_code: 404}}
   end
+
+  def successful_refund() do
+    {:ok, %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514408064,\"transaction\":{\"updated_at\":1514408064,\"status\":\"refunded\",\"short_id\":\"0000.9999.0000\",\"response_code\":20000,\"refunds\":[\"refund_1840867e0632e776d307\"],\"preauthorization\":null,\"payment\":\"pay_0a22787c797a150f40ad32fc\",\"origin_amount\":100,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":false,\"is_markable_as_fraud\":true,\"is_fraud\":false,\"invoices\":[],\"id\":\"tran_8e3c8746b274c89930cd2a38ed43\",\"fees\":[],\"description\":\"\",\"currency\":\"EUR\",\"created_at\":1514408006,\"client\":\"client_d9a15a3bc9edd53b7d3b\",\"app_id\":null,\"amount\":0},\"status\":\"refunded\",\"short_id\":\"0000.9999.0000\",\"response_code\":20000,\"reason\":null,\"livemode\":false,\"id\":\"refund_1840867e0632e776d307\",\"description\":null,\"created_at\":1514408064,\"app_id\":null,\"amount\":100}}",
+      request_url: "https://api.paymill.com/v2.1/refunds/tran_8e3c8746b274c89930cd2a38ed43",
+      status_code: 200}}
+  end
+
+  def refund_with_invalid_trans_token() do
+    {:ok, %HTTPoison.Response{body: "{\"exception\":\"transaction_not_found\",\"error\":\"Transaction not found\"}",
+      request_url: "https://api.paymill.com/v2.1/refunds/tran_8e3c8746b274c89930cd2a38e123",
+      status_code: 404}}
+  end
+
+  def refund_with_high_amount() do
+    {:ok, %HTTPoison.Response{body: "{\"exception\":\"refund_amount_to_high\",\"error\":\"Amount to high\"}",
+      request_url: "https://api.paymill.com/v2.1/refunds/tran_d9df8ae460354befe6aee6916fbf",
+      status_code: 400}}
+  end
 end

--- a/test/mocks/paymill_mock.exs
+++ b/test/mocks/paymill_mock.exs
@@ -16,14 +16,32 @@ defmodule Gringotts.Gateways.PaymillMock do
   end
 
   def authorize_invalid_card_token() do
-    {:ok, %HTTPoison.Response{body: "{\n\t\"error\":{\n\t\t\"messages\":{\n\t\t\t\"regexNotMatch\":\"'tok_123' does not match against pattern '\\/^[a-zA-Z0-9_]{32}$\\/'\"\n\t\t},\n\t\t\"field\":\"token\"\n\t}\n}",
+    {:ok, %HTTPoison.Response{body: "{\"error\":{\"messages\":{\"regexNotMatch\":\"'tok_123' does not match against pattern '/^[a-zA-Z0-9_]{32}$/'\"},\"field\":\"token\"}}",
       request_url: "https://api.paymill.com/v2.1/preauthorizations",
       status_code: 400}}
   end
 
   def authorize_invalid_currency() do
-    {:ok, %HTTPoison.Response{body: "{\n\t\"error\":{\n\t\t\"messages\":{\n\t\t\t\"notInArray\":\"'ABC' was not found in the haystack\"\n\t\t},\n\t\t\"field\":\"currency\"\n\t}\n}",
+    {:ok, %HTTPoison.Response{body: "{\"error\":{\"messages\":{\"notInArray\":\"'ABC' was not found in the haystack\"},\"field\":\"currency\"}}",
       request_url: "https://api.paymill.com/v2.1/preauthorizations",
       status_code: 400}}
+  end
+
+  def successful_capture() do
+    {:ok, %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514396484,\"status\":\"closed\",\"short_id\":\"0000.9999.0000\",\"response_code\":20000,\"refunds\":null,\"preauthorization\":{\"updated_at\":1514396459,\"transaction\":\"tran_478351595d1ec1e65d32d97e2696\",\"status\":\"closed\",\"payment\":\"pay_d9eef5928b69760cd60c4784\",\"livemode\":false,\"id\":\"preauth_7dc9457660b33759b70b\",\"description\":null,\"currency\":\"INR\",\"created_at\":1514396457,\"client\":\"client_436f5667c0835f3adf2c\",\"app_id\":null,\"amount\":\"200\"},\"payment\":{\"updated_at\":1514396441,\"type\":\"creditcard\",\"last4\":\"1111\",\"is_usable_for_preauthorization\":true,\"is_recurring\":true,\"id\":\"pay_d9eef5928b69760cd60c4784\",\"expire_year\":\"2020\",\"expire_month\":\"3\",\"created_at\":1514396441,\"country\":\"DE\",\"client\":\"client_436f5667c0835f3adf2c\",\"card_type\":\"visa\",\"card_holder\":\"Sagar Karwande\",\"app_id\":null},\"origin_amount\":2000,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":true,\"is_markable_as_fraud\":true,\"is_fraud\":false,\"invoices\":[],\"id\":\"tran_478351595d1ec1e65d32d97e2696\",\"fees\":[],\"description\":\"\",\"currency\":\"EUR\",\"created_at\":1514396441,\"client\":{\"updated_at\":1514396441,\"subscription\":null,\"payment\":[\"pay_d9eef5928b69760cd60c4784\"],\"id\":\"client_436f5667c0835f3adf2c\",\"email\":null,\"description\":null,\"created_at\":1514396441,\"app_id\":null},\"app_id\":null,\"amount\":2000}}",
+      request_url: "https://api.paymill.com/v2.1/transactions",
+      status_code: 200}}
+  end
+
+  def capture_with_used_auth do
+    {:ok, %HTTPoison.Response{body: "{\"exception\":\"preauthorization_already_used\",\"error\":\"Preauthorization has already been used\"}",
+      request_url: "https://api.paymill.com/v2.1/transactions",
+      status_code: 409}}
+  end
+
+  def capture_with_invalid_auth_token do
+    {:ok, %HTTPoison.Response{body: "{\"exception\":\"not_found_transaction_preauthorize\",\"error\":\"Preauthorize not found\"}",
+     request_url: "https://api.paymill.com/v2.1/transactions",
+     status_code: 404}}
   end
 end

--- a/test/mocks/paymill_mock.exs
+++ b/test/mocks/paymill_mock.exs
@@ -1,0 +1,29 @@
+defmodule Gringotts.Gateways.PaymillMock do
+  @moduledoc false
+
+  def successful_authorize() do
+    {:ok,
+      %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514371900,\"transaction\":{\"updated_at\":1514371900,\"status\":\"preauth\",\"short_id\":null,\"response_code\":20000,\"refunds\":null,\"preauthorization\":\"preauth_7e160b01c8a570d513e8\",\"payment\":\"pay_a2934f6a2a5f65f6dfa337d3\",\"origin_amount\":100,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":false,\"is_markable_as_fraud\":true,\"is_frau d\":false,\"invoices\":[],\"id\":\"tran_1352d28a96c3a31b2a145748786f\",\"fees\":[],\"description\":null,\"currency\":\"EUR\",\"created_at\":1514371897,\"client\":\"client_c38ce0f295edc5773027\",\"app_id\":null,\"amount\":100},\"status\":\"closed\",\"payment\":{\"updated_at\":1514371897,\"type\":\"creditcard\",\"last4\":\"1111\",\"is_usable_for_preauthorization\":true,\"is_recurring\":true,\"id\":\"pay_a2934f6a2a5f65f6dfa337d3\",\"expire_year\":\"2018\",\"e xpire_month\":\"12\",\"created_at\":1514371897,\"country\":\"DE\",\"client\":\"client_c38ce0f295edc5773027\",\"card_type\":\"visa\",\"card_holder\":\"Sagar   Karwande\",\"app_id\":null},\"livemode\":false,\"id\":\"preauth_7e160b01c8a570d513e8\",\"description\":null,\"currency\":\"EUR\",\"created_at\":1514371898,\"client\":{\"updated_at\":1514371897,\"subscription\":null,\"payment\":[\"pay_a2934f6a2a5f65f6dfa337d3\"],\"id\":\"client_c38ce0f295edc5773027\",\"email\":null,\"description\":null,\"created_at\":1514371897,\"app_id\":null},\"app_id\":null,\"amount\":\"100\"}}",
+      request_url: "https://api.paymill.com/v2.1/preauthorizations",
+      status_code: 200}}
+  end
+
+  def authorize_invalid_cvv() do
+    {:ok,
+      %HTTPoison.Response{body: "{\"mode\":\"test\",\"data\":{\"updated_at\":1514373790,\"transaction\":{\"updated_at\":1514373790,\"status\":\"failed\",\"short_id\":null,\"response_code\":50800,\"refunds\":null,\"preauthorization\":\"preauth_8e2cc0cb547097246cfd\",\"payment\":\"pay_ff6f4eafa56f68e1aa894a94\",\"origin_amount\":100,\"mandate_reference\":null,\"livemode\":false,\"is_refundable\":false,\"is_markable_as_fraud\":true,\"is_fraud\":false,\"invoices\":[],\"id\":\"tran_5a0398849b093a193c9a065a40b2\",\"fees\":[],\"description\":null,\"currency\":\"EUR\",\"created_at\":1514373675,\"client\":\"client_08c47a5372b1d96db907\",\"app_id\":null,\"amount\":100},\"status\":\"failed\",\"payment\":{\"updated_at\":1514373675,\"type\":\"creditcard\",\"last4\":\"5100\",\"is_usable_for_preauthorization\":true,\"is_recurring\":true,\"id\":\"pay_ff6f4eafa56f68e1aa894a94\",\"expire_year\":\"2020\",\"expire_month\":\"8\",\"created_at\":1514373675,\"country\":\"DE\",\"client\":\"client_08c47a5372b1d96db907\",\"card_type\":\"mastercard\",\"card_holder\":\"Sagar Karwande\",\"app_id\":null},\"livemode\":false,\"id\":\"preauth_8e2cc0cb547097246cfd\",\"description\":null,\"currency\":\"EUR\",\"created_at\":1514373788,\"client\":{\"updated_at\":1514373675,\"subscription\":null,\"payment\":[\"pay_ff6f4eafa56f68e1aa894a94\"],\"id\":\"client_08c47a5372b1d96db907\",\"email\":null,\"description\":null,\"created_at\":1514373675,\"app_id\":null},\"app_id\":null,\"amount\":\"100\"}}",
+      request_url: "https://api.paymill.com/v2.1/preauthorizations",
+      status_code: 200}}
+  end
+
+  def authorize_invalid_card_token() do
+    {:ok, %HTTPoison.Response{body: "{\n\t\"error\":{\n\t\t\"messages\":{\n\t\t\t\"regexNotMatch\":\"'tok_123' does not match against pattern '\\/^[a-zA-Z0-9_]{32}$\\/'\"\n\t\t},\n\t\t\"field\":\"token\"\n\t}\n}",
+      request_url: "https://api.paymill.com/v2.1/preauthorizations",
+      status_code: 400}}
+  end
+
+  def authorize_invalid_currency() do
+    {:ok, %HTTPoison.Response{body: "{\n\t\"error\":{\n\t\t\"messages\":{\n\t\t\t\"notInArray\":\"'ABC' was not found in the haystack\"\n\t\t},\n\t\t\"field\":\"currency\"\n\t}\n}",
+      request_url: "https://api.paymill.com/v2.1/preauthorizations",
+      status_code: 400}}
+  end
+end


### PR DESCRIPTION
Added mock test for following methods
- Authorize
- Capture
- Purchase
- Void
- Refund

Refactored gateway ResponseHandler for some edge cases.
Added refund functionality.

## TODO
* [ ] Mock test for save_card
- [x] Support for money protocol
- [x] Add docs and examples

## Edit
1. Many tests are misleading/wrong (for ex: `authorize with invalid cvv`)
2. `ResponseHandler` has a lot of opportunities for refactoring.
3. `save_card` and `save` can probably be used as `store`.
4. The whole token business should be documented in the `moduledoc`