### PR TITLE
Modified Gringotts Public Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ address = %Address{
 
 opts = [address: address, currency: "eur"]
 
-case Gringotts.purchase(:payment_worker, Stripe, 10, card, opts) do
+case Gringotts.purchase(Stripe, 10, card, opts) do
   {:ok,    %{authorization: authorization}} ->
     IO.puts("Payment authorized #{authorization}")
 

--- a/lib/gringotts.ex
+++ b/lib/gringotts.ex
@@ -36,14 +36,6 @@ defmodule Gringotts do
   The public API is designed in such a way that library users end up passing mostly a 
   standard params for almost all requests.
 
-  ### Worker Name 
-    eg: :payment_worker
-
-    The standard central supervised worker responsible for delegating/calling all
-    the payment specific methods such as `authorise` & `purchase`.
-
-    > This option is going to be removed in our next version.
-
   ### Gateway Name
     eg: Gringotts.Gateways.Stripe
 
@@ -103,15 +95,15 @@ defmodule Gringotts do
 
       @options [currency: "usd"]
 
-      Gringotts.purchase(:payment_worker, Gringotts.Gateways.Stripe, 5, @payment, @options)
+      Gringotts.purchase(Gringotts.Gateways.Stripe, 5, @payment, @options)
 
   This method is expected to authorize payment and transparently trigger eventual 
   settlement. Preferably it is implemented as a single call to the gateway, 
   but it can also be implemented as chained `authorize` and `capture` calls.
   """
-  def purchase(worker, gateway, amount, card, opts \\ []) do
+  def purchase(gateway, amount, card, opts \\ []) do
     validate_config(gateway)
-    call(worker, {:purchase, gateway, amount, card, opts})
+    call(:payment_worker, {:purchase, gateway, amount, card, opts})
   end
 
   @doc """
@@ -135,11 +127,11 @@ defmodule Gringotts do
 
       @options [currency: "usd"]
 
-      Gringotts.authorize(:payment_worker, Gringotts.Gateways.Stripe, 5, @payment, @options)
+      Gringotts.authorize(Gringotts.Gateways.Stripe, 5, @payment, @options)
   """
-  def authorize(worker, gateway, amount, card, opts \\ []) do
+  def authorize(gateway, amount, card, opts \\ []) do
     validate_config(gateway)
-    call(worker, {:authorize, gateway, amount, card, opts})
+    call(:payment_worker, {:authorize, gateway, amount, card, opts})
   end
 
   @doc """
@@ -169,11 +161,11 @@ defmodule Gringotts do
 
       id = "ch_1BYvGkBImdnrXiZwet3aKkQE"
 
-      Gringotts.capture(:payment_worker, Gringotts.Gateways.Stripe, id, 5)
+      Gringotts.capture(Gringotts.Gateways.Stripe, id, 5)
   """
-  def capture(worker, gateway, id, amount, opts \\ []) do 
+  def capture(gateway, id, amount, opts \\ []) do 
     validate_config(gateway)
-    call(worker, {:capture, gateway, id, amount, opts})
+    call(:payment_worker, {:capture, gateway, id, amount, opts})
   end
 
   @doc """
@@ -198,12 +190,12 @@ defmodule Gringotts do
 
       id = "ch_1BYvGkBImdnrXiZwet3aKkQE"
 
-      Gringotts.void(:payment_worker, Gringotts.Gateways.Stripe, id)
+      Gringotts.void(Gringotts.Gateways.Stripe, id)
 
   """
-  def void(worker, gateway, id, opts \\ []) do 
+  def void(gateway, id, opts \\ []) do 
     validate_config(gateway)
-    call(worker, {:void, gateway, id, opts})
+    call(:payment_worker, {:void, gateway, id, opts})
   end
 
   @doc """
@@ -225,11 +217,11 @@ defmodule Gringotts do
 
       id = "ch_1BYvGkBImdnrXiZwet3aKkQE"
 
-      Gringotts.refund(:payment_worker, Gringotts.Gateways.Stripe, 5, id)
+      Gringotts.refund(Gringotts.Gateways.Stripe, 5, id)
   """
-  def refund(worker, gateway, amount, id, opts \\ []) do 
+  def refund(gateway, amount, id, opts \\ []) do 
     validate_config(gateway)
-    call(worker, {:refund, gateway, amount, id, opts})
+    call(:payment_worker, {:refund, gateway, amount, id, opts})
   end
 
   @doc """
@@ -258,11 +250,11 @@ defmodule Gringotts do
 
       id = "ch_1BYvGkBImdnrXiZwet3aKkQE"
 
-      Gringotts.store(:payment_worker, Gringotts.Gateways.Stripe, @payment)
+      Gringotts.store(Gringotts.Gateways.Stripe, @payment)
   """
-  def store(worker, gateway, card, opts \\ []) do 
+  def store(gateway, card, opts \\ []) do 
     validate_config(gateway)
-    call(worker, {:store, gateway, card, opts})
+    call(:payment_worker, {:store, gateway, card, opts})
   end
 
   @doc """
@@ -274,11 +266,11 @@ defmodule Gringotts do
 
       customer_id = "random_customer"
 
-      Gringotts.unstore(:payment_worker, Gringotts.Gateways.Stripe, customer_id)
+      Gringotts.unstore(Gringotts.Gateways.Stripe, customer_id)
   """
-  def unstore(worker, gateway, customer_id, opts \\ []) do 
+  def unstore(gateway, customer_id, opts \\ []) do 
     validate_config(gateway)
-    call(worker, {:unstore, gateway, customer_id, opts})
+    call(:payment_worker, {:unstore, gateway, customer_id, opts})
   end
 
   # TODO: This is runtime error reporting fix this so that it does compile

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -161,7 +161,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
       iex> card = %CreditCard{number: "5424000000000015", year: 2020, month: 12, verification_code: "999"}
       iex> amount = 5
-      iex> result = Gringotts.purchase(:payment_worker, Gringotts.Gateways.AuthorizeNet, amount, card, opts)
+      iex> result = Gringotts.purchase(Gringotts.Gateways.AuthorizeNet, amount, card, opts)
   """
   @spec purchase(Float, CreditCard.t, Keyword.t) :: tuple
   def purchase(amount, payment, opts) do
@@ -214,7 +214,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
       iex> card = %CreditCard{number: "5424000000000015", year: 2020, month: 12, verification_code: "999"}
       iex> amount = 5
-      iex> result = Gringotts.authorize(:payment_worker, Gringotts.Gateways.AuthorizeNet, amount, card, opts)
+      iex> result = Gringotts.authorize(Gringotts.Gateways.AuthorizeNet, amount, card, opts)
   """
   @spec authorize(Float, CreditCard.t, Keyword.t) :: tuple
   def authorize(amount, payment, opts) do
@@ -251,7 +251,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
       iex> amount = 5
       iex> id = "123456"
-      iex> result = Gringotts.capture(:payment_worker, Gringotts.Gateways.AuthorizeNet, id, amount, opts)
+      iex> result = Gringotts.capture(Gringotts.Gateways.AuthorizeNet, id, amount, opts)
   """
   @spec capture(String.t, Float, Keyword.t) :: tuple
   def capture(id, amount, opts) do
@@ -281,7 +281,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
       iex> id = "123456"
       iex> amount = 5
-      iex> result = Gringotts.refund(:payment_worker, Gringotts.Gateways.AuthorizeNet, amount, id, opts)
+      iex> result = Gringotts.refund(Gringotts.Gateways.AuthorizeNet, amount, id, opts)
   """
   @spec refund(Float, String.t, Keyword.t) :: tuple
   def refund(amount, id, opts) do
@@ -305,7 +305,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
         ref_id: "123456"
       ]
       iex> id = "123456"
-      iex> result = Gringotts.void(:payment_worker, Gringotts.Gateways.AuthorizeNet, id, opts)
+      iex> result = Gringotts.void(Gringotts.Gateways.AuthorizeNet, id, opts)
   """
   @spec void(String.t, Keyword.t) :: tuple
   def void(id, opts) do
@@ -348,7 +348,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
         validation_mode: "testMode"
       ]
       iex> card = %CreditCard{number: "5424000000000015", year: 2020, month: 12, verification_code: "999"}
-      iex> result = Gringotts.store(:payment_worker, Gringotts.Gateways.AuthorizeNet, card, opts)
+      iex> result = Gringotts.store(Gringotts.Gateways.AuthorizeNet, card, opts)
   """
   @spec store(CreditCard.t, Keyword.t) :: tuple
   def store(card, opts) do
@@ -369,7 +369,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   ## Example
       iex> id = "123456"
       iex> opts = []
-      iex> result = Gringotts.store(:payment_worker, Gringotts.Gateways.AuthorizeNet, id, opts)
+      iex> result = Gringotts.store(Gringotts.Gateways.AuthorizeNet, id, opts)
   """
   
   @spec unstore(String.t, Keyword.t) :: tuple

--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -116,7 +116,7 @@ defmodule Gringotts.Gateways.Cams do
       options = [currency: "USD"]
       money   = 100
       
-      iex> Gringotts.purchase(:payment_worker, Gringotts.Gateways.Cams, money, payment, options)
+      iex> Gringotts.purchase(Gringotts.Gateways.Cams, money, payment, options)
   """
   @spec purchase(number, CreditCard.t, Keyword) :: Response
   def purchase(money, payment, options) do
@@ -150,7 +150,7 @@ defmodule Gringotts.Gateways.Cams do
       options = [currency: "USD"]
       money   = 100
       
-      iex> Gringotts.authorize(:payment_worker, Gringotts.Gateways.Cams, money, payment, options)
+      iex> Gringotts.authorize(Gringotts.Gateways.Cams, money, payment, options)
   """
   @spec authorize(number, CreditCard.t, Keyword) :: Response
   def authorize(money, payment, options) do
@@ -175,7 +175,7 @@ defmodule Gringotts.Gateways.Cams do
       options = [currency: "USD"]
       money   = 100
       
-      iex> Gringotts.capture(:payment_worker, Gringotts.Gateways.Cams, money, authorization, options)
+      iex> Gringotts.capture(Gringotts.Gateways.Cams, money, authorization, options)
   """
   @spec capture(number, String.t, Keyword) :: Response
   def capture(money, authorization, options) do
@@ -202,7 +202,7 @@ defmodule Gringotts.Gateways.Cams do
       options = [currency: "USD"]
       money   = 100
       
-      iex> Gringotts.refund(:payment_worker, Gringotts.Gateways.Cams, money, authorization, options)
+      iex> Gringotts.refund(Gringotts.Gateways.Cams, money, authorization, options)
   """
   @spec refund(number, String.t, Keyword) :: Response
   def refund(money, authorization, options) do
@@ -223,7 +223,7 @@ defmodule Gringotts.Gateways.Cams do
       authorization = "3904093075"
       options = []
       
-      iex> Gringotts.void(:payment_worker, Gringotts.Gateways.Cams, authorization, options)
+      iex> Gringotts.void(Gringotts.Gateways.Cams, authorization, options)
   """
   @spec void(String.t, Keyword) :: Response
   def void(authorization , options) do

--- a/lib/gringotts/gateways/monei.ex
+++ b/lib/gringotts/gateways/monei.ex
@@ -180,7 +180,7 @@ defmodule Gringotts.Gateways.Monei do
 
       iex> opts = [currency: "EUR"] # The default currency is EUR, and this is just for an example.
       iex> card = %Gringotts.CreditCard{first_name: "Jo", last_name: "Doe", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
-      iex> auth_result = Gringotts.authorize(:payment_worker, Gringotts.Gateways.Monei, 40, card, opts)
+      iex> auth_result = Gringotts.authorize(Gringotts.Gateways.Monei, 40, card, opts)
       iex> auth_result.id # This is the authorization ID
   """
   @spec authorize(number, CreditCard.t(), keyword) :: {:ok | :error, Response}
@@ -221,7 +221,7 @@ defmodule Gringotts.Gateways.Monei do
 
       iex> opts = [currency: "EUR"] # The default currency is EUR, and this is just for an example.
       iex> card = %Gringotts.CreditCard{first_name: "Jo", last_name: "Doe", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
-      iex> capture_result = Gringotts.capture(:payment_worker, Gringotts.Gateways.Monei, 35, auth_result.id, opts)
+      iex> capture_result = Gringotts.capture(Gringotts.Gateways.Monei, 35, auth_result.id, opts)
   """
   @spec capture(number, String.t(), keyword) :: {:ok | :error, Response}
   def capture(amount, payment_id, opts)
@@ -254,7 +254,7 @@ defmodule Gringotts.Gateways.Monei do
 
       iex> opts = [currency: "EUR"] # The default currency is EUR, and this is just for an example.
       iex> card = %Gringotts.CreditCard{first_name: "Jo", last_name: "Doe", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
-      iex> purchase_result = Gringotts.purchase(:payment_worker, Gringotts.Gateways.Monei, 40, card, opts)
+      iex> purchase_result = Gringotts.purchase(Gringotts.Gateways.Monei, 40, card, opts)
   """
   @spec purchase(number, CreditCard.t(), keyword) :: {:ok | :error, Response}
   def purchase(amount, card = %CreditCard{}, opts) when is_integer(amount) do
@@ -305,7 +305,7 @@ defmodule Gringotts.Gateways.Monei do
 
       iex> opts = [currency: "EUR"] # The default currency is EUR, and this is just for an example.
       iex> card = %Gringotts.CreditCard{first_name: "Jo", last_name: "Doe", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
-      iex> void_result = Gringotts.void(:payment_worker, Gringotts.Gateways.Monei, auth_result.id, opts)
+      iex> void_result = Gringotts.void(Gringotts.Gateways.Monei, auth_result.id, opts)
   """
   @spec void(String.t(), keyword) :: {:ok | :error, Response}
   def void(payment_id, opts)
@@ -334,7 +334,7 @@ defmodule Gringotts.Gateways.Monei do
 
       iex> opts = [currency: "EUR"] # The default currency is EUR, and this is just for an example.
       iex> card = %Gringotts.CreditCard{first_name: "Jo", last_name: "Doe", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
-      iex> refund_result = Gringotts.refund(:payment_worker, Gringotts.Gateways.Monei, purchase_result.id, opts)
+      iex> refund_result = Gringotts.refund(Gringotts.Gateways.Monei, purchase_result.id, opts)
   """
   @spec refund(number, String.t(), keyword) :: {:ok | :error, Response}
   def refund(amount, payment_id, opts) when is_integer(amount) do
@@ -374,7 +374,7 @@ defmodule Gringotts.Gateways.Monei do
 
       iex> opts = [currency: "EUR"] # The default currency is EUR, and this is just for an example.
       iex> card = %Gringotts.CreditCard{first_name: "Jo", last_name: "Doe", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
-      iex> store_result = Gringotts.store(:payment_worker, Gringotts.Gateways.Monei, card, opts)
+      iex> store_result = Gringotts.store(Gringotts.Gateways.Monei, card, opts)
   """
   @spec store(CreditCard.t(), keyword) :: {:ok | :error, Response}
   def store(%CreditCard{} = card, opts) do

--- a/lib/gringotts/gateways/paymill.ex
+++ b/lib/gringotts/gateways/paymill.ex
@@ -55,7 +55,7 @@ defmodule Gringotts.Gateways.Paymill do
 
       options = []
 
-      iex> Gringotts.authorize(:payment_worker, Gringotts.Gateways.Paymill, amount, card, options)
+      iex> Gringotts.authorize(Gringotts.Gateways.Paymill, amount, card, options)
   """
   @spec authorize(number, String.t | CreditCard.t, Keyword) :: {:ok | :error, Response}
   def authorize(amount, card_or_token, options) do
@@ -80,7 +80,7 @@ defmodule Gringotts.Gateways.Paymill do
 
       options = []
 
-      iex> Gringotts.purchase(:payment_worker, Gringotts.Gateways.Paymill, amount, card, options)
+      iex> Gringotts.purchase(Gringotts.Gateways.Paymill, amount, card, options)
   """
   @spec purchase(number, CreditCard.t, Keyword) :: {:ok | :error, Response}
   def purchase(amount, card, options) do
@@ -98,7 +98,7 @@ defmodule Gringotts.Gateways.Paymill do
 
       options = []
 
-      iex> Gringotts.capture(:payment_worker, Gringotts.Gateways.Paymill, token, amount, options)
+      iex> Gringotts.capture(Gringotts.Gateways.Paymill, token, amount, options)
   """
   @spec capture(String.t, number, Keyword) :: {:ok | :error, Response}
   def capture(authorization, amount, options) do
@@ -115,7 +115,7 @@ defmodule Gringotts.Gateways.Paymill do
 
       options = []
 
-      iex> Gringotts.void(:payment_worker, Gringotts.Gateways.Paymill, token, options)
+      iex> Gringotts.void(Gringotts.Gateways.Paymill, token, options)
   """
   @spec void(String.t, Keyword) :: {:ok | :error, Response}
   def void(authorization, options) do

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -92,7 +92,7 @@ defmodule Gringotts.Gateways.Stripe do
       iex> opts = [currency: "usd"]
       iex> amount = 10
 
-      iex> Gringotts.authorize(:payment_worker, Gringotts.Gateways.Stripe, amount, payment, opts)
+      iex> Gringotts.authorize(Gringotts.Gateways.Stripe, amount, payment, opts)
   """
   @spec authorize(Float, Map, List) :: Map
   def authorize(amount, payment, opts \\ []) do
@@ -119,7 +119,7 @@ defmodule Gringotts.Gateways.Stripe do
       iex> opts = [currency: "usd"]
       iex> amount = 5
 
-      iex> Gringotts.purchase(:payment_worker, Gringotts.Gateways.Stripe, amount, payment, opts)
+      iex> Gringotts.purchase(Gringotts.Gateways.Stripe, amount, payment, opts)
   """
   @spec purchase(Float, Map, List) :: Map
   def purchase(amount, payment, opts \\ []) do
@@ -145,7 +145,7 @@ defmodule Gringotts.Gateways.Stripe do
       iex> amount = 5
       iex> opts = []
 
-      iex> Gringotts.capture(:payment_worker, Gringotts.Gateways.Stripe, id, amount, opts)
+      iex> Gringotts.capture(Gringotts.Gateways.Stripe, id, amount, opts)
   """
   @spec capture(String.t, Float, List) :: Map
   def capture(id, amount, opts \\ []) do
@@ -178,7 +178,7 @@ defmodule Gringotts.Gateways.Stripe do
       iex> id = "ch_1BYvGkBImdnrXiZwet3aKkQE"
       iex> opts = []
 
-      iex> Gringotts.void(:payment_worker, Gringotts.Gateways.Stripe, id, opts)
+      iex> Gringotts.void(Gringotts.Gateways.Stripe, id, opts)
   """
   @spec void(String.t, List) :: Map
   def void(id, opts \\ []) do
@@ -200,7 +200,7 @@ defmodule Gringotts.Gateways.Stripe do
       iex> id = "ch_1BYvGkBImdnrXiZwet3aKkQE"
       iex> opts = []
 
-      iex> Gringotts.refund(:payment_worker, Gringotts.Gateways.Stripe, amount, id, opts)
+      iex> Gringotts.refund(Gringotts.Gateways.Stripe, amount, id, opts)
   """
   @spec refund(Float, String.t, List) :: Map
   def refund(amount, id, opts \\ []) do
@@ -226,7 +226,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> opts = []
 
-      iex> Gringotts.store(:payment_worker, Gringotts.Gateways.Stripe, payment, opts)
+      iex> Gringotts.store(Gringotts.Gateways.Stripe, payment, opts)
   """
   @spec store(Map, List) :: Map
   def store(payment, opts \\ []) do
@@ -245,7 +245,7 @@ defmodule Gringotts.Gateways.Stripe do
   The following session shows how one would unstore a already stored payment source.
       iex> id = "cus_BwpLX2x4ecEUgD"
 
-      iex> Gringotts.unstore(:payment_worker, Gringotts.Gateways.Stripe, id, opts)
+      iex> Gringotts.unstore(Gringotts.Gateways.Stripe, id, opts)
   """
   @spec unstore(String.t) :: Map
   def unstore(id, opts \\ []), do: commit(:delete, "customers/#{id}", [], opts)

--- a/test/gringotts_test.exs
+++ b/test/gringotts_test.exs
@@ -49,33 +49,33 @@ defmodule GringottsTest do
   end
 
   test "authorization" do
-    assert authorize(:payment_worker, GringottsTest.FakeGateway, 100, :card, []) ==
+    assert authorize(GringottsTest.FakeGateway, 100, :card, []) ==
              :authorization_response
   end
 
   test "purchase" do
-    assert purchase(:payment_worker, GringottsTest.FakeGateway, 100, :card, []) ==
+    assert purchase(GringottsTest.FakeGateway, 100, :card, []) ==
              :purchase_response
   end
 
   test "capture" do
-    assert capture(:payment_worker, GringottsTest.FakeGateway, 1234, 100, []) == :capture_response
+    assert capture(GringottsTest.FakeGateway, 1234, 100, []) == :capture_response
   end
 
   test "void" do
-    assert void(:payment_worker, GringottsTest.FakeGateway, 1234, []) == :void_response
+    assert void(GringottsTest.FakeGateway, 1234, []) == :void_response
   end
 
   test "refund" do
-    assert refund(:payment_worker, GringottsTest.FakeGateway, 100, 1234, []) == :refund_response
+    assert refund(GringottsTest.FakeGateway, 100, 1234, []) == :refund_response
   end
 
   test "store" do
-    assert store(:payment_worker, GringottsTest.FakeGateway, :card, []) == :store_response
+    assert store(GringottsTest.FakeGateway, :card, []) == :store_response
   end
 
   test "unstore" do
-    assert unstore(:payment_worker, GringottsTest.FakeGateway, 123, []) == :unstore_response
+    assert unstore(GringottsTest.FakeGateway, 123, []) == :unstore_response
   end
 
   test "validate_config when some required config is missing" do
@@ -84,7 +84,7 @@ defmodule GringottsTest do
     assert_raise(
       ArgumentError,
       "expected [:other_secret] to be set, got: [adapter: GringottsTest.FakeGateway, some_auth_info: :merchant_secret_key]\n",
-      fn -> authorize(:payment_worker, GringottsTest.FakeGateway, 100, :card, []) end
+      fn -> authorize(GringottsTest.FakeGateway, 100, :card, []) end
     )
   end
 end

--- a/test/integration/gateways/monei_test.exs
+++ b/test/integration/gateways/monei_test.exs
@@ -26,7 +26,7 @@ defmodule Gringotts.Integration.Gateways.MoneiTest do
   end
 
   test "authorize." do
-    case Gringotts.authorize(:payment_worker, Gateway, 3.1, @card) do
+    case Gringotts.authorize(Gateway, 3.1, @card) do
       {:ok, response} ->
         assert response.code == "000.100.110"
         assert response.description == "Request successfully processed in 'Merchant in Integrator Test Mode'"
@@ -37,7 +37,7 @@ defmodule Gringotts.Integration.Gateways.MoneiTest do
 
   @tag :skip
   test "capture." do
-    case Gringotts.capture(:payment_worker, Gateway, 32.00, "s") do
+    case Gringotts.capture(Gateway, 32.00, "s") do
       {:ok, response} ->
         assert response.code == "000.100.110"
         assert response.description == "Request successfully processed in 'Merchant in Integrator Test Mode'"
@@ -48,7 +48,7 @@ defmodule Gringotts.Integration.Gateways.MoneiTest do
   end
 
   test "purchase." do
-    case Gringotts.purchase(:payment_worker, Gateway, 32, @card) do
+    case Gringotts.purchase(Gateway, 32, @card) do
       {:ok, response} ->
         assert response.code == "000.100.110"
         assert response.description == "Request successfully processed in 'Merchant in Integrator Test Mode'"


### PR DESCRIPTION
Removed `:payment_worker` argument to be explicitly given while calling the public Api.
Fixes #7.
Following changes were made.
1. Removed the worker argument from public api.
2. Removed the payment worker from the examples of gateway files.

**Earlier** the api needed to be called this way. 
```elixir
 Gringotts.purchase(:payment_worker, Gringotts.Gateways.Stripe, 5, @payment, @options)
```

**Now** it needs to be this way.
```elixir
  Gringotts.purchase(Gringotts.Gateways.Stripe, 5, @payment, @options)
```