### PR TITLE
Stripe gateway minor fixes and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Copy and paste this code in your module
 
 ```elixir
 alias Gringotts.Gateways.Stripe
-alias Gringotts.{CreditCard, Address, Worker, Gateways}
+alias Gringotts.{CreditCard, Address}
 
 card = %CreditCard{
   first_name: "John",

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ card = %CreditCard{
   first_name: "John",
   last_name: "Smith",
   number: "4242424242424242",
-  year: "2017",
+  year: "2022",
   month: "12",
   verification_code: "123"
 }

--- a/lib/gringotts/credit_card.ex
+++ b/lib/gringotts/credit_card.ex
@@ -43,5 +43,9 @@ defmodule Gringotts.CreditCard do
   Joins `first_name` and `last_name` with a space in between.
   """
   @spec full_name(t) :: String.t
-  def full_name(card), do: "#{card.first_name} #{card.last_name}"
+  def full_name(card) do
+    name = "#{card.first_name} #{card.last_name}"
+    String.trim(name)    
+  end
+
 end

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -296,7 +296,7 @@ defmodule Gringotts.Gateways.Stripe do
     |> with_currency(params, opts[:config])
   end
 
-  def with_currency(true, params, config), do: params
+  def with_currency(true, params, _), do: params
   def with_currency(false, params, config), do: [{:currency, config[:default_currency]} | params]
 
   defp create_card_token(params, opts) do
@@ -328,7 +328,7 @@ defmodule Gringotts.Gateways.Stripe do
     end
   end
 
-  defp source_params(_, opts), do: []
+  defp source_params(_, _), do: []
 
   defp card_params(%CreditCard{} = card) do
     [ "card[name]": CreditCard.full_name(card),

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -83,16 +83,27 @@ defmodule Gringotts.Gateways.Stripe do
   ## Example
   The following session shows how one would (pre) authorize a payment of $10 on a sample `card`.
   
-      iex> payment = %{
-            expiration: {2018, 12}, number: "4242424242424242", cvc:  "123", name: "John Doe",
-            street1: "123 Main", street2: "Suite 100", city: "New York", region: "NY", country: "US",
+      iex> card = %CreditCard{
+            first_name: "John",
+            last_name: "Smith",
+            number: "4242424242424242",
+            year: "2017",
+            month: "12",
+            verification_code: "123"
+          }
+
+          address = %Address{
+            street1: "123 Main",
+            city: "New York",
+            region: "NY",
+            country: "US",
             postal_code: "11111"
           }
 
-      iex> opts = [currency: "usd"]
+      iex> opts = [currency: "usd", address: address]
       iex> amount = 10
 
-      iex> Gringotts.authorize(Gringotts.Gateways.Stripe, amount, payment, opts)
+      iex> Gringotts.authorize(Gringotts.Gateways.Stripe, amount, card, opts)
   """
   @spec authorize(Float, Map, List) :: Map
   def authorize(amount, payment, opts \\ []) do
@@ -110,16 +121,27 @@ defmodule Gringotts.Gateways.Stripe do
   The following session shows how one would process a payment in one-shot,
   without (pre) authorization.
 
-      iex> payemnt = %{
-            expiration: {2018, 12}, number: "4242424242424242", cvc:  "123", name: "John Doe",
-            street1: "123 Main", street2: "Suite 100", city: "New York", region: "NY", country: "US",
+      iex> card = %CreditCard{
+            first_name: "John",
+            last_name: "Smith",
+            number: "4242424242424242",
+            year: "2017",
+            month: "12",
+            verification_code: "123"
+          }
+
+          address = %Address{
+            street1: "123 Main",
+            city: "New York",
+            region: "NY",
+            country: "US",
             postal_code: "11111"
           }
 
-      iex> opts = [currency: "usd"]
+      iex> opts = [currency: "usd", address: address]
       iex> amount = 5
 
-      iex> Gringotts.purchase(Gringotts.Gateways.Stripe, amount, payment, opts)
+      iex> Gringotts.purchase(Gringotts.Gateways.Stripe, amount, card, opts)
   """
   @spec purchase(Float, Map, List) :: Map
   def purchase(amount, payment, opts \\ []) do
@@ -218,15 +240,26 @@ defmodule Gringotts.Gateways.Stripe do
   The following session shows how one would store a card (a payment-source) for
   future use.
       
-      iex> payment = %{
-            expiration: {2018, 12}, number: "4242424242424242", cvc:  "123", name: "John Doe",
-            street1: "123 Main", street2: "Suite 100", city: "New York", region: "NY", country: "US",
+      iex> card = %CreditCard{
+            first_name: "John",
+            last_name: "Smith",
+            number: "4242424242424242",
+            year: "2017",
+            month: "12",
+            verification_code: "123"
+          }
+
+          address = %Address{
+            street1: "123 Main",
+            city: "New York",
+            region: "NY",
+            country: "US",
             postal_code: "11111"
           }
 
-      iex> opts = []
+      iex> opts = [address: address]
 
-      iex> Gringotts.store(Gringotts.Gateways.Stripe, payment, opts)
+      iex> Gringotts.store(Gringotts.Gateways.Stripe, card, opts)
   """
   @spec store(Map, List) :: Map
   def store(payment, opts \\ []) do

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -105,7 +105,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.authorize(Gringotts.Gateways.Stripe, amount, card, opts)
   """
-  @spec authorize(Float, Map, List) :: Map
+  @spec authorize(number, CreditCard.t() | String.t(), keyword) :: map
   def authorize(amount, payment, opts \\ []) do
     params = create_params_for_auth_or_purchase(amount, payment, opts, false)
     commit(:post, "charges", params, opts)
@@ -143,7 +143,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.purchase(Gringotts.Gateways.Stripe, amount, card, opts)
   """
-  @spec purchase(Float, Map, List) :: Map
+  @spec purchase(number, CreditCard.t() | String.t(), keyword) :: map
   def purchase(amount, payment, opts \\ []) do
     params = create_params_for_auth_or_purchase(amount, payment, opts)
     commit(:post, "charges", params, opts)
@@ -169,7 +169,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.capture(Gringotts.Gateways.Stripe, id, amount, opts)
   """
-  @spec capture(String.t, Float, List) :: Map
+  @spec capture(String.t(), number, keyword) :: map
   def capture(id, amount, opts \\ []) do
     params = optional_params(opts) ++ amount_params(amount)
     commit(:post, "charges/#{id}/capture", params, opts)
@@ -202,7 +202,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.void(Gringotts.Gateways.Stripe, id, opts)
   """
-  @spec void(String.t, List) :: Map
+  @spec void(String.t(), keyword) :: map
   def void(id, opts \\ []) do
     params = optional_params(opts)
     commit(:post, "charges/#{id}/refund", params, opts)
@@ -224,7 +224,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.refund(Gringotts.Gateways.Stripe, amount, id, opts)
   """
-  @spec refund(Float, String.t, List) :: Map
+  @spec refund(number, String.t(), keyword) :: map
   def refund(amount, id, opts \\ []) do
     params = optional_params(opts) ++ amount_params(amount)
     commit(:post, "charges/#{id}/refund", params, opts)
@@ -261,7 +261,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.store(Gringotts.Gateways.Stripe, card, opts)
   """
-  @spec store(Map, List) :: Map
+  @spec store(CreditCard.t() | String.t(), keyword) :: map
   def store(payment, opts \\ []) do
     params = optional_params(opts) ++ source_params(payment, opts)
     commit(:post, "customers", params, opts)
@@ -280,7 +280,7 @@ defmodule Gringotts.Gateways.Stripe do
 
       iex> Gringotts.unstore(Gringotts.Gateways.Stripe, id, opts)
   """
-  @spec unstore(String.t) :: Map
+  @spec unstore(String.t()) :: map
   def unstore(id, opts \\ []), do: commit(:delete, "customers/#{id}", [], opts)
 
   # Private methods

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -272,6 +272,14 @@ defmodule Gringotts.Gateways.Stripe do
 
   defp amount_params(amount), do: [amount: money_to_cents(amount)]
 
+  defp source_params(token_or_customer, _) when is_binary(token_or_customer) do
+    [head, _] = String.split(token_or_customer, "_")
+    case head do
+      "tok" -> [source: token_or_customer]
+      "cus" -> [customer: token_or_customer]
+    end
+  end
+
   defp source_params(%CreditCard{} = card, opts) do
     params = 
       card_params(card) ++ 
@@ -283,15 +291,7 @@ defmodule Gringotts.Gateways.Stripe do
       true -> []
       false -> response
         |> Map.get("id")
-        |> source_params
-    end
-  end
-
-  defp source_params(token_or_customer) do
-    [head, _] = String.split(token_or_customer, "_")
-    case head do
-      "tok" -> [source: token_or_customer]
-      "cus" -> [customer: token_or_customer]
+        |> source_params(opts)
     end
   end
 

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -331,7 +331,7 @@ defmodule Gringotts.Gateways.Stripe do
   defp source_params(_, opts), do: []
 
   defp card_params(%CreditCard{} = card) do
-    [ "card[name]": CreditCard.full_name,
+    [ "card[name]": CreditCard.full_name(card),
       "card[number]": card.number,
       "card[exp_year]": card.year,
       "card[exp_month]": card.month,

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -329,7 +329,6 @@ defmodule Gringotts.Gateways.Stripe do
   defp commit(method, path, params \\ [], opts \\ []) do
     auth_token = "Bearer " <> opts[:config][:secret_key]
     headers = [{"Content-Type", "application/x-www-form-urlencoded"}, {"Authorization", auth_token}]
-   
     data = params_to_string(params)
     response = HTTPoison.request(method, "#{@base_url}/#{path}", data, headers)
     format_response(response)

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -329,6 +329,7 @@ defmodule Gringotts.Gateways.Stripe do
   defp commit(method, path, params \\ [], opts \\ []) do
     auth_token = "Bearer " <> opts[:config][:secret_key]
     headers = [{"Content-Type", "application/x-www-form-urlencoded"}, {"Authorization", auth_token}]
+   
     data = params_to_string(params)
     response = HTTPoison.request(method, "#{@base_url}/#{path}", data, headers)
     format_response(response)

--- a/lib/gringotts/gateways/stripe.ex
+++ b/lib/gringotts/gateways/stripe.ex
@@ -298,29 +298,23 @@ defmodule Gringotts.Gateways.Stripe do
   defp source_params(_, opts), do: []
 
   defp card_params(%CreditCard{} = card) do
-    card = Map.from_struct(card)
-
-    [ 
-      "card[name]": card[:name],
-      "card[number]": card[:number],
-      "card[exp_year]": card[:year],
-      "card[exp_month]": card[:month],
-      "card[cvc]": card[:verification_code]
+    [ "card[name]": CreditCard.full_name,
+      "card[number]": card.number,
+      "card[exp_year]": card.year,
+      "card[exp_month]": card.month,
+      "card[cvc]": card.verification_code
     ]   
   end
 
   defp card_params(_), do: []
 
   defp address_params(%Address{} = address) do
-    address = Map.from_struct(address)
-
-    [ 
-      "card[address_line1]": address[:street1],
-      "card[address_line2]": address[:street2],
-      "card[address_city]":  address[:city],
-      "card[address_state]": address[:region],
-      "card[address_zip]":   address[:postal_code],
-      "card[address_country]": address[:country]
+    [ "card[address_line1]": address.street1,
+      "card[address_line2]": address.street2,
+      "card[address_city]":  address.city,
+      "card[address_state]": address.region,
+      "card[address_zip]":   address.postal_code,
+      "card[address_country]": address.country
     ]
   end
 


### PR DESCRIPTION
* add guard clause when source params is token or customer
* trim name since it will contain the extra space when first_name or last_name is not passed in card struct.
*  don't change the struct into map, access card params from struct only
* change stripe docs according to new credit card and address struct
* change expiration year in README.md