### PR TITLE
[trexle] Adds Money protocol 

### DIFF
--- a/lib/gringotts/gateways/trexle.ex
+++ b/lib/gringotts/gateways/trexle.ex
@@ -121,7 +121,7 @@ defmodule Gringotts.Gateways.Trexle do
   a sample `card`.
 
   ```
-  iex> amount = %{value: Decimal.new(100, :USD)
+  iex> amount = %{value: Decimal.new(100),currency: "USD")
   iex> card = %CreditCard{
                first_name: "Harry",
                last_name: "Potter",
@@ -171,7 +171,7 @@ defmodule Gringotts.Gateways.Trexle do
   authorized a payment worth $10 by referencing the obtained `charge_token`.
 
   ```
-  iex> amount = %{value: Decimal.new(10, :USD)
+  iex> amount = %{value: Decimal.new(100),currency: "USD")
   iex> token = "some-real-token"
   iex> Gringotts.capture(Gringotts.Gateways.Trexle, token, amount)
   ```
@@ -195,7 +195,7 @@ defmodule Gringotts.Gateways.Trexle do
   one-shot, without (pre) authorization.
 
   ```
-  iex> amount = %{value: Decimal.new(100, :USD)
+  iex> amount = %{value: Decimal.new(100),currency: "USD")
   iex> card = %CreditCard{
                first_name: "Harry",
                last_name: "Potter",
@@ -243,7 +243,7 @@ defmodule Gringotts.Gateways.Trexle do
   `purchase/3` (and similarily for `capture/3`s).
 
   ```
-  iex> amount = %{value: Decimal.new(100, :USD)
+  iex> amount = %{value: Decimal.new(100),currency: "USD")
   iex> token = "some-real-token"
   iex> Gringotts.refund(Gringotts.Gateways.Trexle, amount, token)
   ```

--- a/lib/gringotts/gateways/trexle.ex
+++ b/lib/gringotts/gateways/trexle.ex
@@ -37,7 +37,7 @@ defmodule Gringotts.Gateways.Trexle do
   @base_url "https://core.trexle.com/api/v1/"
 
   use Gringotts.Gateways.Base
-  use Gringotts.Adapter, required_config: [:api_key, :default_currency]
+  use Gringotts.Adapter, required_config: [:api_key]
   import Poison, only: [decode: 1]
   alias Gringotts.{Response, CreditCard, Address, Money}
 

--- a/lib/gringotts/gateways/trexle.ex
+++ b/lib/gringotts/gateways/trexle.ex
@@ -1,9 +1,9 @@
 defmodule Gringotts.Gateways.Trexle do
 
   @moduledoc """
-  Trexle Payment Gateway Implementation:
+  [Trexle][home] Payment Gateway implementation.
 
-  For further details, please refer [Trexle API documentation](https://docs.trexle.com/).
+  > For further details, please refer [Trexle API documentation][docs].
 
   Following are the features that have been implemented for the Trexle Gateway:
 
@@ -16,22 +16,87 @@ defmodule Gringotts.Gateways.Trexle do
   | Store                        | `store/2`     |
 
   ## The `opts` argument
-  A `Keyword` list `opts` passed as an optional argument for transactions with the gateway. Following are the keys
+
+  Most `Gringotts` API calls accept an optional `keyword` list `opts` to supply
+  optional arguments for transactions with Trexle. The following keys are
   supported:
 
-  * email
-  * ip_address
-  * description
+  * `email`
+  * `ip_address`
+  * `description`
 
-  ## Trexle account registeration with `Gringotts`
-  After creating your account successfully on [Trexle](https://docs.trexle.com/) follow the [dashboard link](https://trexle.com/dashboard/api-keys) to fetch the secret api_key.
+  [docs]: https://docs.trexle.com/
+  [home]: https://trexle.com/
+
+  ## Registering your Trexle account at `Gringotts`
+
+  After [creating your account][dashboard] successfully on Trexle, head to the dashboard and find
+  your account "secrets" in the [`API keys`][keys] section.
+
+  Here's how the secrets map to the required configuration parameters for MONEI:
+
+  | Config parameter | Trexle secret   |
+  | -------          | ----            |
+  | `:api_key`       | **API key**     |
 
   Your Application config must look something like this:
 
       config :gringotts, Gringotts.Gateways.Trexle,
           adapter: Gringotts.Gateways.Trexle,
-          api_key: "Secret API key",
-          default_currency: "USD"
+          api_key: "your-secret-API-key"
+
+  [dashboard]: https://trexle.com/dashboard/
+  [keys]: https://trexle.com/dashboard/api-keys
+
+  ## Scope of this module
+
+  * Trexle processes money in cents.**citation-needed**.
+
+  ## Supported Gateways
+
+  Find the official [list here][gateways].
+
+  [gateways]: https://trexle.com/payment-gateway
+
+  ## Following the examples
+
+  1. First, set up a sample application and configure it to work with Trexle.
+  - You could do that from scratch by following our [Getting Started][gs] guide.
+      - To save you time, we recommend [cloning our example repo][example-repo]
+        that gives you a pre-configured sample app ready-to-go.
+        + You could use the same config or update it the with your "secrets"
+          that as described
+          [above](#module-registering-your-trexle-account-at-gringotts).
+
+  2. Run an `iex` session with `iex -S mix` and add some variable bindings and
+  aliases to it (to save some time):
+  ```
+  iex> alias Gringotts.{Response, CreditCard, Gateways.Trexle}
+  iex> card = %CreditCard{
+               first_name: "Harry",
+               last_name: "Potter",
+               number: "4200000000000000",
+               year: 2099, month: 12,
+               verification_code: "123",
+               brand: "VISA"}
+  iex> address = %Address{
+                  street1: "301, Gryffindor",
+                  street2: "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
+                  city: "Highlands",
+                  region: "SL",
+                  country: "GB",
+                  postal_code: "11111",
+                  phone: "(555)555-5555"}
+  iex> options = [email: "masterofdeath@ministryofmagic.gov",
+                  ip_address: "127.0.0.1",
+                  billing_address: address,
+                  description: "For our valued customer, Mr. Potter"]
+  ```
+
+  We'll be using these in the examples below.
+
+  [example-repo]: https://github.com/aviabird/gringotts_example
+  [gs]: #
   """
 
   @base_url "https://core.trexle.com/api/v1/"
@@ -42,120 +107,122 @@ defmodule Gringotts.Gateways.Trexle do
   alias Gringotts.{Response, CreditCard, Address, Money}
 
   @doc """
-  Performs the authorization of the card to be used for payment.
+  Performs a (pre) Authorize operation.
 
-  Authorizes your card with the given amount and returns a charge token and captured status as false in response.
+  The authorization validates the `card` details with the banking network,
+  places a hold on the transaction `amount` in the customer’s issuing bank and
+  also triggers risk management. Funds are not transferred.
+
+  Trexle returns a "charge token", avaliable in the `Response.authorization`
+  field, which can be used in future to perform a `capture/3`.
 
   ### Example
+
+  The following session shows how one would (pre) authorize a payment of $100 on
+  a sample `card`.
+
   ```
-  iex> amount = 100
-
+  iex> amount = %{value: Decimal.new(100, :USD)
   iex> card = %CreditCard{
-    number: "5200828282828210",
-    month: 12,
-    year: 2018,
-    first_name: "John",
-    last_name: "Doe",
-    verification_code: "123",
-    brand: "visa"
-  }
-
+               first_name: "Harry",
+               last_name: "Potter",
+               number: "5200828282828210",
+               year: 2099, month: 12,
+               verification_code: "123",
+               brand: "VISA"}
   iex> address = %Address{
-    street1: "123 Main",
-    street2: "Suite 100",
-    city: "New York",
-    region: "NY",
-    country: "US",
-    postal_code: "11111",
-    phone: "(555)555-5555"
-  }
-
-  iex> options = [email: "john@trexle.com", ip_address: "66.249.79.118", billing_address: address, description: "Store Purchase 1437598192"]
-
-  iex> Gringotts.authorize(:payment_worker, Gringotts.Gateways.Trexle, amount, card, options)
+                  street1: "301, Gryffindor",
+                  street2: "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
+                  city: "Highlands",
+                  region: "SL",
+                  country: "GB",
+                  postal_code: "11111",
+                  phone: "(555)555-5555"}
+  iex> options = [email: "masterofdeath@ministryofmagic.gov",
+                  ip_address: "127.0.0.1",
+                  billing_address: address,
+                  description: "For our valued customer, Mr. Potter"]
+  iex> Gringotts.authorize(Gringotts.Gateways.Trexle, amount, card, options)
   ```
   """
-
-  @spec authorize(Money.t, CreditCard.t, list) :: map
+  @spec authorize(Money.t, CreditCard.t, keyword) :: {:ok | :error, Response}
   def authorize(amount, payment, opts \\ []) do
     params = create_params_for_auth_or_purchase(amount, payment, opts, false)
     commit(:post, "charges", params, opts)
   end
 
   @doc """
-  Performs the amount transfer from the customer to the merchant.
+  Captures a pre-authorized `amount`.
 
-  The actual amount deduction performed by Trexle using the customer's card info.
+  `amount` is transferred to the merchant account by MONEI when it is smaller or
+  equal to the amount used in the pre-authorization referenced by `charge_token`.
+
+  Trexle returns a "charge token", avaliable in the `Response.authorization`
+  field, which can be used in future to perform a `refund/2`.
+
+  ## Note
+
+  Multiple captures cannot be performed on the same "charge token". If the
+  captured amount is smaller than the (pre) authorized amount, the "un-captured"
+  amount is released.**citation-needed**
 
   ## Example
+
+  The following example shows how one would (partially) capture a previously
+  authorized a payment worth $10 by referencing the obtained `charge_token`.
+
   ```
-  iex> card = %CreditCard{
-    number: "5200828282828210",
-    month: 12,
-    year: 2018,
-    first_name: "John",
-    last_name: "Doe",
-    verification_code: "123",
-    brand: "visa"
-  }
-
-  iex> address = %Address{
-    street1: "123 Main",
-    street2: "Suite 100",
-    city: "New York",
-    region: "NY",
-    country: "US",
-    postal_code: "11111",
-    phone: "(555)555-5555"
-  }
-
-  iex> options = [email: "john@trexle.com", ip_address: "66.249.79.118" ,billing_address: address, description: "Store Purchase 1437598192"]
-
-  iex> @address %Address{
-    street1: "123 Main",
-    street2: "Suite 100",
-    city: "New York",
-    region: "NY",
-    country: "US",
-    postal_code: "11111",
-    phone: "(555)555-5555"
-  }
-
-  iex> options = [email: "john@trexle.com", ip_address: "66.249.79.118" ,billing_address: @address, description: "Store Purchase 1437598192"]
-
-  iex> amount = 50
-
-  iex> Gringotts.purchase(:payment_worker, Gringotts.Gateways.Trexle, amount, card, options)
+  iex> amount = %{value: Decimal.new(10, :USD)
+  iex> token = "some-real-token"
+  iex> Gringotts.capture(Gringotts.Gateways.Trexle, token, amount)
   ```
   """
-
-  @spec purchase(Money.t, CreditCard.t, list) :: map
-  def purchase(amount, payment, opts \\ []) do
-    params = create_params_for_auth_or_purchase(amount, payment, opts)
-    commit(:post, "charges", params, opts)
+  @spec capture(String.t, Money.t, keyword) :: {:ok | :error, Response}
+  def capture(charge_token, amount, opts \\ []) do
+    {_, int_value, _} = Money.to_integer(amount)
+    params = [amount: int_value]
+    commit(:put, "charges/#{charge_token}/capture", params, opts)
   end
 
   @doc """
-  Captures a particular amount using the charge token of a pre authorized card.
+  Transfers `amount` from the customer to the merchant.
 
-  The amount specified should be less than or equal to the amount given prior to capture while authorizing the card.
-  If the amount mentioned is less than the amount given in authorization process, the mentioned amount is debited.
-  Please note that multiple captures can't be performed for a given charge token from the authorization process.
+  Trexle attempts to process a purchase on behalf of the customer, by debiting
+  `amount` from the customer's account by charging the customer's `card`.
 
-  ### Example
+  ## Example
+
+  The following session shows how one would process a payment worth $100 in
+  one-shot, without (pre) authorization.
+
   ```
-  iex> amount = 100
-
-  iex> token = "charge_6a5fcdc6cdbf611ee3448a9abad4348b2afab3ec"
-
-  iex> Gringotts.capture(:payment_worker, Gringotts.Gateways.Trexle, token, amount)
+  iex> amount = %{value: Decimal.new(100, :USD)
+  iex> card = %CreditCard{
+               first_name: "Harry",
+               last_name: "Potter",
+               number: "5200828282828210",
+               year: 2099, month: 12,
+               verification_code: "123",
+               brand: "VISA"}
+  iex> address = %Address{
+                  street1: "301, Gryffindor",
+                  street2: "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
+                  city: "Highlands",
+                  region: "SL",
+                  country: "GB",
+                  postal_code: "11111",
+                  phone: "(555)555-5555"}
+  iex> options = [email: "masterofdeath@ministryofmagic.gov",
+                  ip_address: "127.0.0.1",
+                  billing_address: address,
+                  description: "For our valued customer, Mr. Potter"]
+  iex> Gringotts.purchase(Gringotts.Gateways.Trexle, amount, card, options)
   ```
   """
-
-  @spec capture(String.t, Money.t, list) :: map
-  def capture(charge_token, amount, opts \\ []) do
-    params = [amount: Money.value(amount)]
-    commit(:put, "charges/#{charge_token}/capture", params, opts)
+  @spec purchase(Money.t, CreditCard.t, keyword) :: {:ok | :error, Response}
+  def purchase(amount, payment, opts \\ []) do
+    params = create_params_for_auth_or_purchase(amount, payment, opts)
+    commit(:post, "charges", params, opts)
   end
 
   @doc """
@@ -164,24 +231,28 @@ defmodule Gringotts.Gateways.Trexle do
   Trexle processes a full or partial refund worth `amount`, referencing a
   previous `purchase/3` or `capture/3`.
 
-  Multiple refund can be performed for the same charge token from purchase or capture done before performing refund action unless the cumulative amount is less than the amount given while authorizing.
+  Trexle returns a "refund token", avaliable in the `Response.authorization`
+  field.
+
+  Multiple, partial refunds can be performed on the same "charge token"
+  referencing a previous `purchase/3` or `capture/3` till the cumulative refunds
+  equals the `capture/3`d or `purchase/3`d amount.
 
   ## Example
-  The following session shows how one would refund a previous purchase (and similarily for captures).
+
+  The following session shows how one would refund $100 of a previous
+  `purchase/3` (and similarily for `capture/3`s).
+
   ```
-  iex> amount = 5
-
-  iex> token = "charge_668d3e169b27d4938b39246cb8c0890b0bd84c3c"
-
-  iex> options = [email: "john@trexle.com", ip_address: "66.249.79.118", description: "Store Purchase 1437598192"]
-
-  iex> Gringotts.refund(:payment_worker, Gringotts.Gateways.Trexle, amount, token, options)
+  iex> amount = %{value: Decimal.new(100, :USD)
+  iex> token = "some-real-token"
+  iex> Gringotts.refund(Gringotts.Gateways.Trexle, amount, token)
   ```
   """
-
-  @spec refund(Money.t, String.t, list) :: map
+  @spec refund(Money.t, String.t, keyword) :: {:ok | :error, Response}
   def refund(amount, charge_token, opts \\ []) do
-    params = [amount: Money.value(amount)]
+    {_, int_value, _} = Money.to_integer(amount)
+    params = [amount: int_value]
     commit(:post, "charges/#{charge_token}/refunds", params, opts)
   end
 
@@ -189,35 +260,33 @@ defmodule Gringotts.Gateways.Trexle do
   Stores the card information for future use.
 
   ## Example
-  The following session shows how one would store a card (a payment-source) for future use.
+
+  The following session shows how one would store a card (a payment-source) for
+  future use.
   ```
   iex> card = %CreditCard{
-    number: "5200828282828210",
-    month: 12,
-    year: 2018,
-    first_name: "John",
-    last_name: "Doe",
-    verification_code: "123",
-    brand: "visa"
-  }
-
+               first_name: "Harry",
+               last_name: "Potter",
+               number: "5200828282828210",
+               year: 2099, month: 12,
+               verification_code: "123",
+               brand: "VISA"}
   iex> address = %Address{
-    street1: "123 Main",
-    street2: "Suite 100",
-    city: "New York",
-    region: "NY",
-    country: "US",
-    postal_code: "11111",
-    phone: "(555)555-5555"
-  }
-
-  iex> options = [email: "john@trexle.com", ip_address: "66.249.79.118", billing_address: address, description: "Store Purchase 1437598192"]
-
-  iex> Gringotts.store(:payment_worker, Gringotts.Gateways.Trexle, card, options)
+                  street1: "301, Gryffindor",
+                  street2: "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
+                  city: "Highlands",
+                  region: "SL",
+                  country: "GB",
+                  postal_code: "11111",
+                  phone: "(555)555-5555"}
+  iex> options = [email: "masterofdeath@ministryofmagic.gov",
+                  ip_address: "127.0.0.1",
+                  billing_address: address,
+                  description: "For our valued customer, Mr. Potter"]
+  iex> Gringotts.store(Gringotts.Gateways.Trexle, card, options)
   ```
   """
-
-  @spec store(CreditCard.t, list) :: map
+  @spec store(CreditCard.t, keyword) :: {:ok | :error, Response}
   def store(payment, opts \\ []) do
     params = [email: opts[:email]]
       ++ card_params(payment)
@@ -226,10 +295,11 @@ defmodule Gringotts.Gateways.Trexle do
   end
 
   defp create_params_for_auth_or_purchase(amount, payment, opts, capture \\ true) do
+    {currency, int_value, _} = Money.to_integer(amount)
     [
       capture: capture,
-      amount: Money.value(amount),
-      currency: Money.currency(amount),
+      amount: int_value,
+      currency: currency,
       email: opts[:email],
       ip_address: opts[:ip_address],
       description: opts[:description]
@@ -261,29 +331,29 @@ defmodule Gringotts.Gateways.Trexle do
   defp commit(method, path, params, opts) do
     auth_token = "Basic #{Base.encode64(opts[:config][:api_key])}"
     headers = [{"Content-Type", "application/x-www-form-urlencoded"}, {"Authorization", auth_token}]
-    data = params_to_string(params)
-    options = [hackney: [:insecure, basic_auth: {opts[:config][:api_key], "password"}]]
+    options = [basic_auth: {opts[:config][:api_key], "password"}]
     url = "#{@base_url}#{path}"
-    response = HTTPoison.request(method, url, data, headers, options)
+    response = HTTPoison.request(method, url, {:form, params}, headers, options)
     response |> respond
   end
 
-  @spec respond(term) ::
-  {:ok, Response} |
-  {:error, Response}
+  @spec respond(term) :: {:ok | :error, Response}
   defp respond(response)
 
   defp respond({:ok, %{status_code: code, body: body}}) when code in [200, 201] do
-    case decode(body) do
-      {:ok, results} -> {:ok, Response.success(raw: results, status_code: code)}
-    end
+    {:ok, results} = decode(body)
+    token = results["response"]["token"]
+    message = results["response"]["status_message"]
+    {:ok, Response.success(authorization: token, message: message, raw: results, status_code: code)}
   end
 
   defp respond({:ok, %{status_code: status_code, body: body}}) do
-    {:error, Response.error(status_code: status_code, raw: body)}
+    {:ok, results} = decode(body)
+    detail = results["detail"]
+    {:error, Response.error(status_code: status_code, message: detail, raw: results)}
   end
 
   defp respond({:error, %HTTPoison.Error{} = error}) do
-    {:error, Response.error(code: error.id, reason: :network_fail?, description: "HTTPoison says '#{error.reason}'")}
+    {:error, Response.error(code: error.id, message: "HTTPoison says '#{error.reason}'")}
   end
 end

--- a/test/gateways/trexle_test.exs
+++ b/test/gateways/trexle_test.exs
@@ -41,8 +41,8 @@ defmodule Gringotts.Gateways.TrexleTest do
     phone: "(555)555-5555"
   }
 
-  @amount 100
-  @bad_amount 20
+  @amount %{amount: Decimal.new(50), currency: "USD"}
+  @bad_amount %{amount: Decimal.new(20), currency: "USD"}
 
   @valid_token "J5RGMpDlFlTfv9mEFvNWYoqHufyukPP4"
   @invalid_token "30"

--- a/test/gateways/trexle_test.exs
+++ b/test/gateways/trexle_test.exs
@@ -1,9 +1,9 @@
 defmodule Gringotts.Gateways.TrexleTest do
-
-  Code.require_file "../mocks/trexle_mock.exs", __DIR__
+  Code.require_file("../mocks/trexle_mock.exs", __DIR__)
   use ExUnit.Case, async: false
   alias Gringotts.Gateways.TrexleMock, as: MockResponse
   alias Gringotts.Gateways.Trexle
+
   alias Gringotts.{
     CreditCard,
     Address
@@ -15,17 +15,21 @@ defmodule Gringotts.Gateways.TrexleTest do
     first_name: "Harry",
     last_name: "Potter",
     number: "4200000000000000",
-    year: 2099, month: 12,
+    year: 2099,
+    month: 12,
     verification_code: "123",
-    brand: "VISA"}
+    brand: "VISA"
+  }
 
   @invalid_card %CreditCard{
     first_name: "Harry",
     last_name: "Potter",
     number: "4200000000000000",
-    year: 2010, month: 12,
+    year: 2010,
+    month: 12,
     verification_code: "123",
-    brand: "VISA"}
+    brand: "VISA"
+  }
 
   @address %Address{
     street1: "301, Gryffindor",
@@ -34,10 +38,13 @@ defmodule Gringotts.Gateways.TrexleTest do
     region: "SL",
     country: "GB",
     postal_code: "11111",
-    phone: "(555)555-5555"}
+    phone: "(555)555-5555"
+  }
 
-  @amount Money.new("2.99", :USD) # $2.99
-  @bad_amount Money.new("0.49", :USD) # 50 US cents, trexle does not work with amount smaller than 50 cents.
+  # $2.99
+  @amount Money.new("2.99", :USD)
+  # 50 US cents, trexle does not work with amount smaller than 50 cents.
+  @bad_amount Money.new("0.49", :USD)
 
   @valid_token "7214344252e11af79c0b9e7b4f3f6234"
   @invalid_token "14a62fff80f24a25f775eeb33624bbb3"
@@ -48,22 +55,27 @@ defmodule Gringotts.Gateways.TrexleTest do
     email: "masterofdeath@ministryofmagic.gov",
     ip_address: "127.0.0.1",
     billing_address: @address,
-    description: "For our valued customer, Mr. Potter"]
+    description: "For our valued customer, Mr. Potter"
+  ]
 
   describe "purchase" do
     test "with valid card" do
       with_mock HTTPoison,
-        [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_purchase_with_valid_card end] do
-          {:ok, response} = Trexle.purchase(@amount, @valid_card, @opts)
-          assert response.status_code == 201
-          assert response.raw["response"]["success"] == true
-          assert response.raw["response"]["captured"] == false
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_purchase_with_valid_card()
+        end do
+        {:ok, response} = Trexle.purchase(@amount, @valid_card, @opts)
+        assert response.status_code == 201
+        assert response.raw["response"]["success"] == true
+        assert response.raw["response"]["captured"] == false
       end
     end
 
     test "with invalid card" do
       with_mock HTTPoison,
-      [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_purchase_with_invalid_card end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_purchase_with_invalid_card()
+        end do
         {:error, response} = Trexle.purchase(@amount, @invalid_card, @opts)
         assert response.status_code == 400
         assert response.success == false
@@ -73,7 +85,9 @@ defmodule Gringotts.Gateways.TrexleTest do
 
     test "with invalid amount" do
       with_mock HTTPoison,
-      [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_purchase_with_invalid_amount end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_purchase_with_invalid_amount()
+        end do
         {:error, response} = Trexle.purchase(@bad_amount, @valid_card, @opts)
         assert response.status_code == 400
         assert response.success == false
@@ -85,7 +99,9 @@ defmodule Gringotts.Gateways.TrexleTest do
   describe "authorize" do
     test "with valid card" do
       with_mock HTTPoison,
-      [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_authorize_with_valid_card end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_authorize_with_valid_card()
+        end do
         {:ok, response} = Trexle.authorize(@amount, @valid_card, @opts)
         assert response.status_code == 201
         assert response.raw["response"]["success"] == true
@@ -97,7 +113,9 @@ defmodule Gringotts.Gateways.TrexleTest do
   describe "refund" do
     test "with valid token" do
       with_mock HTTPoison,
-      [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_authorize_with_valid_card end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_authorize_with_valid_card()
+        end do
         {:ok, response} = Trexle.refund(@amount, @valid_token, @opts)
         assert response.status_code == 201
         assert response.raw["response"]["success"] == true
@@ -109,7 +127,9 @@ defmodule Gringotts.Gateways.TrexleTest do
   describe "capture" do
     test "with valid charge token" do
       with_mock HTTPoison,
-      [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_capture_with_valid_chargetoken end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_capture_with_valid_chargetoken()
+        end do
         {:ok, response} = Trexle.capture(@valid_token, @amount, @opts)
         assert response.status_code == 200
         assert response.raw["response"]["success"] == true
@@ -119,20 +139,24 @@ defmodule Gringotts.Gateways.TrexleTest do
     end
 
     test "with invalid charge token" do
-     with_mock HTTPoison,
-     [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_capture_with_invalid_chargetoken end] do
-      {:error, response} = Trexle.capture(@invalid_token, @amount, @opts)
-      assert response.status_code == 400
-      assert response.success == false
-      assert response.message == "invalid token"
-     end
+      with_mock HTTPoison,
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_capture_with_invalid_chargetoken()
+        end do
+        {:error, response} = Trexle.capture(@invalid_token, @amount, @opts)
+        assert response.status_code == 400
+        assert response.success == false
+        assert response.message == "invalid token"
+      end
     end
   end
 
   describe "store" do
     test "with valid card" do
       with_mock HTTPoison,
-        [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_store_with_valid_card end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_store_with_valid_card()
+        end do
         {:ok, response} = Trexle.store(@valid_card, @opts)
         assert response.status_code == 201
       end
@@ -142,7 +166,9 @@ defmodule Gringotts.Gateways.TrexleTest do
   describe "network failure" do
     test "with authorization" do
       with_mock HTTPoison,
-        [request: fn(_method, _url, _body, _headers, _options) -> MockResponse.test_for_network_failure end] do
+        request: fn _method, _url, _body, _headers, _options ->
+          MockResponse.test_for_network_failure()
+        end do
         {:error, response} = Trexle.authorize(@amount, @valid_card, @opts)
         assert response.success == false
         assert response.message == "HTTPoison says 'some_hackney_error'"

--- a/test/mocks/trexle_mock.exs
+++ b/test/mocks/trexle_mock.exs
@@ -120,23 +120,6 @@ defmodule Gringotts.Gateways.TrexleMock do
     }
   end
 
-  def test_for_authorize_with_missing_ip_address do
-    {:ok,
-      %HTTPoison.Response{body: "{\"error\":\"ip_address is missing\"}",
-        headers: [
-          {"Date", "Thu, 28 Dec 2017 12:22:43 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "97bae548-a446-42e9-b792-8c505c38f4c1"},
-          {"X-Runtime", "0.005652"}, {"Content-Length", "33"},
-          {"X-Powered-By", "PleskLin"}, {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1/charges",
-        status_code: 500
-      }
-    }
-  end
-
   def test_for_refund_with_valid_token do
     {:ok,
       %HTTPoison.Response{
@@ -238,6 +221,6 @@ defmodule Gringotts.Gateways.TrexleMock do
   end
 
   def test_for_network_failure do
-    {:error, %HTTPoison.Error{id: nil, reason: :nxdomain}}
+    {:error, %HTTPoison.Error{id: :some_hackney_error_id, reason: :some_hackney_error}}
   end
 end

--- a/test/mocks/trexle_mock.exs
+++ b/test/mocks/trexle_mock.exs
@@ -1,223 +1,197 @@
 defmodule Gringotts.Gateways.TrexleMock do
-
   def test_for_purchase_with_valid_card do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"response\":{\"token\":\"charge_3e89c6f073606ac1efe62e76e22dd7885441dc72\",\"success\":true,\"captured\":false}}",
-        headers: [
-          {"Date", "Fri, 22 Dec 2017 11:57:28 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"ETag", "W/\"5a9f44c457a4fdd0478c82ec1af64816\""},
-          {"Cache-Control", "max-age=0, private, must-revalidate"},
-          {"X-Request-Id", "9b2a1d30-9bca-48f2-862e-4090766689cb"},
-          {"X-Runtime", "0.777520"},
-          {"Content-Length", "104"},
-          {"X-Powered-By", "PleskLin"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges",
-        status_code: 201
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"response":{"token":"charge_3e89c6f073606ac1efe62e76e22dd7885441dc72","success":true,"captured":false}}/,
+      headers: [
+        {"Date", "Fri, 22 Dec 2017 11:57:28 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "max-age=0, private, must-revalidate"},
+        {"X-Request-Id", "9b2a1d30-9bca-48f2-862e-4090766689cb"},
+        {"X-Runtime", "0.777520"},
+        {"Content-Length", "104"},
+        {"X-Powered-By", "PleskLin"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges",
+      status_code: 201
+    }}
   end
 
   def test_for_purchase_with_invalid_card do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"error\":\"Payment failed\",\"detail\":\"Your card's expiration year is invalid.\"}",
-        headers: [
-          {"Date", "Fri, 22 Dec 2017 13:20:50 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "eb8100a1-8ffa-47da-9623-8d3b2af51b84"},
-          {"X-Runtime", "0.445244"},
-          {"Content-Length", "77"},
-          {"X-Powered-By", "PleskLin"},
-          {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges",
-        status_code: 400
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"error":"Payment failed","detail":"Your card's expiration year is invalid."}/,
+      headers: [
+        {"Date", "Fri, 22 Dec 2017 13:20:50 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "no-cache"},
+        {"X-Request-Id", "eb8100a1-8ffa-47da-9623-8d3b2af51b84"},
+        {"X-Runtime", "0.445244"},
+        {"Content-Length", "77"},
+        {"X-Powered-By", "PleskLin"},
+        {"Connection", "close"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges",
+      status_code: 400
+    }}
   end
 
   def test_for_purchase_with_invalid_amount do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"error\":\"Payment failed\",\"detail\":\"Amount must be at least 50 cents\"}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:16:33 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "4ce2eea4-3ea9-4345-ac85-9bc45f22f5ac"},
-          {"X-Runtime", "0.476058"},
-          {"Content-Length", "70"},
-          {"X-Powered-By", "PleskLin"},
-          {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges",
-        status_code: 400
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"error":"Payment failed","detail":"Amount must be at least 50 cents"}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:16:33 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "no-cache"},
+        {"X-Request-Id", "4ce2eea4-3ea9-4345-ac85-9bc45f22f5ac"},
+        {"X-Runtime", "0.476058"},
+        {"Content-Length", "70"},
+        {"X-Powered-By", "PleskLin"},
+        {"Connection", "close"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges",
+      status_code: 400
+    }}
   end
 
   def test_for_authorize_with_valid_card do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"response\":{\"token\":\"charge_8ab2b21a2f02495f5c36b34d129c8a0e836add32\",\"success\":true,\"captured\":false}}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:33:31 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"ETag", "W/\"ec4f2df0607614f67286ac46eb994150\""},
-          {"Cache-Control", "max-age=0, private, must-revalidate"},
-          {"X-Request-Id", "51d28d13-81e5-41fd-b711-1b6531fdd3dd"},
-          {"X-Runtime", "0.738395"},
-          {"Content-Length", "104"},
-          {"X-Powered-By", "PleskLin"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges",
-        status_code: 201
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"response":{"token":"charge_8ab2b21a2f02495f5c36b34d129c8a0e836add32","success":true,"captured":false}}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:33:31 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "max-age=0, private, must-revalidate"},
+        {"X-Request-Id", "51d28d13-81e5-41fd-b711-1b6531fdd3dd"},
+        {"X-Runtime", "0.738395"},
+        {"Content-Length", "104"},
+        {"X-Powered-By", "PleskLin"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges",
+      status_code: 201
+    }}
   end
 
   def test_for_authorize_with_invalid_card do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"error\":\"Payment failed\",\"detail\":\"Your card's expiration year is invalid.\"}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:25:40 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "239e7054-9500-4a87-bf3b-09456d550b6d"},
-          {"X-Runtime", "0.466670"},
-          {"Content-Length", "77"},
-          {"X-Powered-By", "PleskLin"},
-          {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges",
-        status_code: 400
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"error":"Payment failed","detail":"Your card's expiration year is invalid."}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:25:40 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "no-cache"},
+        {"X-Request-Id", "239e7054-9500-4a87-bf3b-09456d550b6d"},
+        {"X-Runtime", "0.466670"},
+        {"Content-Length", "77"},
+        {"X-Powered-By", "PleskLin"},
+        {"Connection", "close"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges",
+      status_code: 400
+    }}
   end
 
   def test_for_authorize_with_invalid_amount do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"error\":\"Payment failed\",\"detail\":\"Amount must be at least 50 cents\"}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:40:10 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "d58db806-8016-4a0e-8519-403a969fa1a7"},
-          {"X-Runtime", "0.494636"},
-          {"Content-Length", "70"},
-          {"X-Powered-By", "PleskLin"},
-          {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges",
-        status_code: 400
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"error":"Payment failed","detail":"Amount must be at least 50 cents"}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:40:10 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "no-cache"},
+        {"X-Request-Id", "d58db806-8016-4a0e-8519-403a969fa1a7"},
+        {"X-Runtime", "0.494636"},
+        {"Content-Length", "70"},
+        {"X-Powered-By", "PleskLin"},
+        {"Connection", "close"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges",
+      status_code: 400
+    }}
   end
 
   def test_for_refund_with_valid_token do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"response\":{\"token\":\"refund_a86a757cc6bdabab50d6ebbfcdcd4db4e04198dd\",\"success\":true,\"amount\":50,\"charge\":\"charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b\",\"status_message\":\"Transaction approved\"}}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:55:41 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"ETag", "W/\"7410ae0b45094aadada390f5c947a58a\""},
-          {"Cache-Control", "max-age=0, private, must-revalidate"},
-          {"X-Request-Id", "b1c94703-7fb4-48f2-b1b4-32e3b6a87e57"},
-          {"X-Runtime", "1.097186"},
-          {"Content-Length", "198"},
-          {"X-Powered-By", "PleskLin"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges/charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b/refunds",
-        status_code: 201
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"response":{"token":"refund_a86a757cc6bdabab50d6ebbfcdcd4db4e04198dd","success":true,"amount":50,"charge":"charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b","status_message":"Transaction approved"}}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:55:41 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "max-age=0, private, must-revalidate"},
+        {"X-Request-Id", "b1c94703-7fb4-48f2-b1b4-32e3b6a87e57"},
+        {"X-Runtime", "1.097186"},
+        {"Content-Length", "198"},
+        {"X-Powered-By", "PleskLin"}
+      ],
+      request_url:
+        "https://core.trexle.com/api/v1//charges/charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b/refunds",
+      status_code: 201
+    }}
   end
 
   def test_for_refund_with_invalid_token do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"error\":\"Refund failed\",\"detail\":\"invalid token\"}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:53:09 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "276fd8f5-dc21-40be-8add-fa76aabbfc5b"},
-          {"X-Runtime", "0.009374"},
-          {"Content-Length", "50"},
-          {"X-Powered-By", "PleskLin"},
-          {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges/34/refunds",
-        status_code: 400
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"error":"Refund failed","detail":"invalid token"}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:53:09 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "no-cache"},
+        {"X-Request-Id", "276fd8f5-dc21-40be-8add-fa76aabbfc5b"},
+        {"X-Runtime", "0.009374"},
+        {"Content-Length", "50"},
+        {"X-Powered-By", "PleskLin"},
+        {"Connection", "close"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges/34/refunds",
+      status_code: 400
+    }}
   end
 
   def test_for_capture_with_valid_chargetoken do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"response\":{\"token\":\"charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b\",\"success\":true,\"captured\":true,\"amount\":50,\"status_message\":\"Transaction approved\"}}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:49:50 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"ETag", "W/\"26f05a32c0d0a27b180bbe777488fd5f\""},
-          {"Cache-Control", "max-age=0, private, must-revalidate"},
-          {"X-Request-Id", "97ca2db6-fd4f-4a5b-ae45-01fae9c13668"},
-          {"X-Runtime", "1.092051"},
-          {"Content-Length", "155"},
-          {"X-Powered-By", "PleskLin"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges/charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b/capture",
-        status_code: 200
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"response":{"token":"charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b","success":true,"captured":true,"amount":50,"status_message":"Transaction approved"}}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:49:50 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "max-age=0, private, must-revalidate"},
+        {"X-Request-Id", "97ca2db6-fd4f-4a5b-ae45-01fae9c13668"},
+        {"X-Runtime", "1.092051"},
+        {"Content-Length", "155"},
+        {"X-Powered-By", "PleskLin"}
+      ],
+      request_url:
+        "https://core.trexle.com/api/v1//charges/charge_cb17a0c34e870a479dfa13bd873e7ce7e090ec9b/capture",
+      status_code: 200
+    }}
   end
 
   def test_for_capture_with_invalid_chargetoken do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"error\":\"Capture failed\",\"detail\":\"invalid token\"}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 18:47:18 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"Cache-Control", "no-cache"},
-          {"X-Request-Id", "b46ecb8d-7df8-4c5f-b87f-c53fae364e79"},
-          {"X-Runtime", "0.010255"},
-          {"Content-Length", "51"},
-          {"X-Powered-By", "PleskLin"},
-          {"Connection", "close"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//charges/30/capture",
-        status_code: 400
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"error":"Capture failed","detail":"invalid token"}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 18:47:18 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "no-cache"},
+        {"X-Request-Id", "b46ecb8d-7df8-4c5f-b87f-c53fae364e79"},
+        {"X-Runtime", "0.010255"},
+        {"Content-Length", "51"},
+        {"X-Powered-By", "PleskLin"},
+        {"Connection", "close"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//charges/30/capture",
+      status_code: 400
+    }}
   end
 
   def test_for_store_with_valid_card do
-    {:ok,
-      %HTTPoison.Response{
-        body: "{\"response\":{\"token\":\"token_94e333959850270460e89a86bad2246613528cbb\",\"card\":{\"token\":\"token_2a1ba29522e4a377fafa62e8e204f76ad8ba8f1e\",\"scheme\":\"master\",\"display_number\":\"XXXX-XXXX-XXXX-8210\",\"expiry_year\":2018,\"expiry_month\":1,\"cvc\":123,\"name\":\"John Doe\",\"address_line1\":\"456 My Street\",\"address_line2\":null,\"address_city\":\"Ottawa\",\"address_state\":\"ON\",\"address_postcode\":\"K1C2N6\",\"address_country\":\"CA\",\"primary\":true}}}",
-        headers: [
-          {"Date", "Sat, 23 Dec 2017 19:32:58 GMT"},
-          {"Content-Type", "application/json; charset=UTF-8"},
-          {"ETag", "W/\"c4089eabe907fc2327dd565503242b58\""},
-          {"Cache-Control", "max-age=0, private, must-revalidate"},
-          {"X-Request-Id", "1a334b22-8e01-4e1b-8b58-90dfd0b7c12f"},
-          {"X-Runtime", "0.122441"},
-          {"Content-Length", "422"},
-          {"X-Powered-By", "PleskLin"}
-        ],
-        request_url: "https://core.trexle.com/api/v1//customers",
-        status_code: 201
-      }
-    }
+    {:ok, %HTTPoison.Response{
+      body: ~s/{"response":{"token":"token_94e333959850270460e89a86bad2246613528cbb","card":{"token":"token_2a1ba29522e4a377fafa62e8e204f76ad8ba8f1e","scheme":"master","display_number":"XXXX-XXXX-XXXX-8210","expiry_year":2018,"expiry_month":1,"cvc":123,"name":"John Doe","address_line1":"456 My Street","address_line2":null,"address_city":"Ottawa","address_state":"ON","address_postcode":"K1C2N6","address_country":"CA","primary":true}}}/,
+      headers: [
+        {"Date", "Sat, 23 Dec 2017 19:32:58 GMT"},
+        {"Content-Type", "application/json; charset=UTF-8"},
+        {"Cache-Control", "max-age=0, private, must-revalidate"},
+        {"X-Request-Id", "1a334b22-8e01-4e1b-8b58-90dfd0b7c12f"},
+        {"X-Runtime", "0.122441"},
+        {"Content-Length", "422"},
+        {"X-Powered-By", "PleskLin"}
+      ],
+      request_url: "https://core.trexle.com/api/v1//customers",
+      status_code: 201
+    }}
   end
 
   def test_for_network_failure do


### PR DESCRIPTION
Uses `Money.to_integer` as Trexle works in cents.
* token and message added to `Response`
* fixed doc examples
* removed unnecessary tests and mocks
 Ran the elixir 1.6 code formatter
    * Used `~s` sigils in mocks