### PR TITLE
[money-protocol] Expansion: `to_string` and `to_integer`

### DIFF
--- a/lib/gringotts/gateways/monei.ex
+++ b/lib/gringotts/gateways/monei.ex
@@ -184,11 +184,12 @@ defmodule Gringotts.Gateways.Monei do
   """
   @spec authorize(Money.t, CreditCard.t(), keyword) :: {:ok | :error, Response}
   def authorize(amount, card = %CreditCard{}, opts) do
+    {currency, value} = Money.to_string amount
     params =
       [
         paymentType: "PA",
-        amount: amount |> Money.value |> Decimal.to_float |> :erlang.float_to_binary(decimals: 2),
-        currency: Money.currency(amount)
+        amount: value,
+        currency: currency,
       ] ++ card_params(card)
 
     auth_info = Keyword.fetch!(opts, :config)
@@ -222,10 +223,11 @@ defmodule Gringotts.Gateways.Monei do
   def capture(amount, payment_id, opts)
 
   def capture(amount, <<payment_id::bytes-size(32)>>, opts) do
+    {currency, value} = Money.to_string amount
     params = [
       paymentType: "CP",
-      amount: amount |> Money.value |> Decimal.to_float |> :erlang.float_to_binary(decimals: 2),
-      currency: Money.currency(amount)
+      amount: value,
+      currency: currency
     ]
 
     auth_info = Keyword.fetch!(opts, :config)
@@ -249,12 +251,13 @@ defmodule Gringotts.Gateways.Monei do
   """
   @spec purchase(Money.t, CreditCard.t(), keyword) :: {:ok | :error, Response}
   def purchase(amount, card = %CreditCard{}, opts) do
+    {currency, value} = Money.to_string amount
     params =
       card_params(card) ++
         [
           paymentType: "DB",
-          amount: amount |> Money.value |> Decimal.to_float |> :erlang.float_to_binary(decimals: 2),
-          currency: Money.currency(amount)
+          amount: value,
+          currency: currency
         ]
 
     auth_info = Keyword.fetch!(opts, :config)
@@ -324,10 +327,11 @@ defmodule Gringotts.Gateways.Monei do
   """
   @spec refund(Money.t, String.t(), keyword) :: {:ok | :error, Response}
   def refund(amount, <<payment_id::bytes-size(32)>>, opts) do
+    {currency, value} = Money.to_string amount
     params = [
       paymentType: "RF",
-      amount: amount |> Money.value |> Decimal.to_float |> :erlang.float_to_binary(decimals: 2),
-      currency: Money.currency(amount)
+      amount: value,
+      currency: currency
     ]
 
     auth_info = Keyword.fetch!(opts, :config)

--- a/lib/gringotts/money.ex
+++ b/lib/gringotts/money.ex
@@ -22,32 +22,32 @@ defprotocol Gringotts.Money do
   is 2 digits after decimal.
   """
   @fallback_to_any true
-  @type t :: Gringotts.Money.t
-  
+  @type t :: Gringotts.Money.t()
+
   @doc """
   Returns the ISO 4217 compliant currency code associated with this sum of money.
 
   This must be an UPCASE `string`
   """
-  @spec currency(t) :: String.t
+  @spec currency(t) :: String.t()
   def currency(money)
 
   @doc """
   Returns a Decimal representing the "worth" of this sum of money in the
   associated `currency`.
   """
-  @spec value(t) :: Decimal.t
+  @spec value(t) :: Decimal.t()
   def value(money)
 
   @doc """
   Returns the ISO4217 `currency` code as string and `value` as an integer.
-  
+
   Useful for gateways that require amount as integer (like cents instead of dollars)
 
   ## Examples
 
       # the money lib is aliased as "MoneyLib"
-  
+
       iex> usd_price = MoneyLib.new(4.1234, :USD)
       #MoneyLib<4.1234, "USD">
       iex> Gringotts.Money.to_integer(usd_price)
@@ -60,7 +60,8 @@ defprotocol Gringotts.Money do
       # the Bahraini dinar is divided into 1000 fils unlike the dollar which is
       # divided in 100 cents
   """
-  @spec to_integer(Money.t) :: {currency :: String.t, value :: integer, exponent :: neg_integer}
+  @spec to_integer(Money.t()) ::
+          {currency :: String.t(), value :: integer, exponent :: neg_integer}
   def to_integer(money)
 
   @doc """
@@ -85,7 +86,7 @@ defprotocol Gringotts.Money do
       iex> Gringotts.Money.to_string(bhd_price)
       {"BHD", "4.123"} 
   """
-  @spec to_string(t) :: {currency :: String.t, value :: String.t}
+  @spec to_string(t) :: {currency :: String.t(), value :: String.t()}
   def to_string(money)
 end
 
@@ -93,25 +94,26 @@ end
 # money)
 if Code.ensure_compiled?(Money) do
   defimpl Gringotts.Money, for: Money do
-    def currency(money), do: money.currency |> Atom.to_string
+    def currency(money), do: money.currency |> Atom.to_string()
     def value(money), do: money.amount
 
     def to_integer(money) do
-      {_, int_value, exponent, _} = Money.to_integer_exp money
+      {_, int_value, exponent, _} = Money.to_integer_exp(money)
       {currency(money), int_value, exponent}
     end
 
     def to_string(money) do
       {:ok, currency_data} = Cldr.Currency.currency_for_code(currency(money))
-      reduced = Money.reduce money
+      reduced = Money.reduce(money)
+
       {
         currency(reduced),
         value(reduced)
         |> Decimal.round(currency_data.digits)
-        |> Decimal.to_string
+        |> Decimal.to_string()
       }
     end
-  end  
+  end
 end
 
 if Code.ensure_compiled?(Monetized.Money) do
@@ -132,15 +134,15 @@ defimpl Gringotts.Money, for: Any do
       value
       |> Decimal.mult(Decimal.new(100))
       |> Decimal.round(0)
-      |> Decimal.to_integer,
+      |> Decimal.to_integer(),
       -2
     }
   end
-  
+
   def to_string(%{value: %Decimal{} = value, currency: currency}) do
     {
       currency,
-      value |> Decimal.round(2) |> Decimal.to_string
+      value |> Decimal.round(2) |> Decimal.to_string()
     }
   end
 end

--- a/lib/gringotts/money.ex
+++ b/lib/gringotts/money.ex
@@ -8,29 +8,85 @@ defprotocol Gringotts.Money do
   If your application is already using a supported Money library, just pass in
   the Money struct and things will work out of the box.
 
-  Otherwise, just wrap your `amount` with the `currency` together in a `Map` like so,
-      money = %{amount: Decimal.new(2017.18), currency: "USD"}
+  Otherwise, just wrap your `amount` with the `currency` together in a `Map`
+  like so,
 
-  and the API will accept it (as long as the currency is valid [ISO 4217 currency
-  code](https://www.iso.org/iso-4217-currency-codes.html)).
+      price = %{amount: Decimal.new(20.18), currency: "USD"}
+
+  and the API will accept it (as long as the currency is valid [ISO 4217
+  currency code](https://www.iso.org/iso-4217-currency-codes.html)).
+
+  ## Note on the `Any` implementation
+
+  Both `to_string` and `to_integer` assume that the precision for the `currency`
+  is 2 digits after decimal.
   """
   @fallback_to_any true
   @type t :: Gringotts.Money.t
   
-  @spec currency(t) :: String.t
   @doc """
   Returns the ISO 4217 compliant currency code associated with this sum of money.
 
   This must be an UPCASE `string`
   """
+  @spec currency(t) :: String.t
   def currency(money)
 
-  @spec value(t) :: Decimal.t
   @doc """
   Returns a Decimal representing the "worth" of this sum of money in the
   associated `currency`.
   """
+  @spec value(t) :: Decimal.t
   def value(money)
+
+  @doc """
+  Returns the ISO4217 `currency` code as string and `value` as an integer.
+  
+  Useful for gateways that require amount as integer (like cents instead of dollars)
+
+  ## Examples
+
+      # the money lib is aliased as "MoneyLib"
+  
+      iex> usd_price = MoneyLib.new(4.1234, :USD)
+      #MoneyLib<4.1234, "USD">
+      iex> Gringotts.Money.to_integer(usd_price)
+      {"USD", 412, -2}
+      
+      iex> bhd_price = MoneyLib.new(4.1234, :BHD)
+      #MoneyLib<4.1234, "USD">
+      iex> Gringotts.Money.to_integer(bhd_price)
+      {"BHD", 4123, -3}
+      # the Bahraini dinar is divided into 1000 fils unlike the dollar which is
+      # divided in 100 cents
+  """
+  @spec to_integer(Money.t) :: {currency :: String.t, value :: integer, exponent :: neg_integer}
+  def to_integer(money)
+
+  @doc """
+  Returns a tuple of ISO4217 `currency` code and the `value` as strings.
+
+  The `value` must match this regex: `~r[\\d+\\.\\d\\d{n}]` where `n+1` should
+  match the required precision for the `currency`.
+
+  > Gringotts will not (and cannot) validate this of course.
+
+  ## Examples
+
+      # the money lib is aliased as "MoneyLib"
+      
+      iex> usd_price = MoneyLib.new(4.1234, :USD)
+      #MoneyLib<4.1234, "USD">
+      iex> Gringotts.Money.to_string(usd_price)
+      {"USD", "4.12"}
+      
+      iex> bhd_price = MoneyLib.new(4.1234, :BHD)
+      #MoneyLib<4.1234, "BHD">
+      iex> Gringotts.Money.to_string(bhd_price)
+      {"BHD", "4.123"} 
+  """
+  @spec to_string(t) :: {currency :: String.t, value :: String.t}
+  def to_string(money)
 end
 
 # this implementation is used for dispatch on ex_money (and will also fire for
@@ -39,6 +95,22 @@ if Code.ensure_compiled?(Money) do
   defimpl Gringotts.Money, for: Money do
     def currency(money), do: money.currency |> Atom.to_string
     def value(money), do: money.amount
+
+    def to_integer(money) do
+      {_, int_value, exponent, _} = Money.to_integer_exp money
+      {currency(money), int_value, exponent}
+    end
+
+    def to_string(money) do
+      {:ok, currency_data} = Cldr.Currency.currency_for_code(currency(money))
+      reduced = Money.reduce money
+      {
+        currency(reduced),
+        value(reduced)
+        |> Decimal.round(currency_data.digits)
+        |> Decimal.to_string
+      }
+    end
   end  
 end
 
@@ -49,7 +121,26 @@ if Code.ensure_compiled?(Monetized.Money) do
   end
 end
 
+# Assumes that the currency is subdivided into 100 units
 defimpl Gringotts.Money, for: Any do
-  def currency(money), do: Map.get(money, :currency)
-  def value(money), do: Map.get(money, :amount) || Map.get(money, :value)
+  def currency(%{currency: currency}), do: currency
+  def value(%{value: %Decimal{} = value}), do: value
+
+  def to_integer(%{value: %Decimal{} = value, currency: currency}) do
+    {
+      currency,
+      value
+      |> Decimal.mult(Decimal.new(100))
+      |> Decimal.round(0)
+      |> Decimal.to_integer,
+      -2
+    }
+  end
+  
+  def to_string(%{value: %Decimal{} = value, currency: currency}) do
+    {
+      currency,
+      value |> Decimal.round(2) |> Decimal.to_string
+    }
+  end
 end

--- a/test/integration/money.exs
+++ b/test/integration/money.exs
@@ -1,0 +1,19 @@
+defmodule Gringotts.Integration.Gateways.MoneyTest do
+  use ExUnit.Case, async: true
+
+  alias Gringotts.Money, as: MoneyProtocol
+
+  @moduletag :integration
+  
+  @ex_money Money.new(42, :EUR)
+  
+  describe "ex_money" do
+    test "amount is a Decimal.t" do
+      assert match? %Decimal{}, MoneyProtocol.value(@ex_money) 
+    end
+
+    test "currency is a String.t" do
+      assert match? currency when is_binary(currency), MoneyProtocol.currency(@ex_money)
+    end
+  end
+end

--- a/test/integration/money.exs
+++ b/test/integration/money.exs
@@ -6,14 +6,29 @@ defmodule Gringotts.Integration.Gateways.MoneyTest do
   @moduletag :integration
   
   @ex_money Money.new(42, :EUR)
+  @ex_money_long Money.new("42.126456", :EUR)
+  @ex_money_bhd Money.new(42, :BHD)
   
   describe "ex_money" do
-    test "amount is a Decimal.t" do
+    test "value is a Decimal.t" do
       assert match? %Decimal{}, MoneyProtocol.value(@ex_money) 
     end
 
-    test "currency is a String.t" do
-      assert match? currency when is_binary(currency), MoneyProtocol.currency(@ex_money)
+    test "currency is an upcase String.t" do
+      the_currency = MoneyProtocol.currency(@ex_money)
+      assert match? currency when is_binary(currency), the_currency
+      assert the_currency == String.upcase(the_currency)
+    end
+
+    test "to_integer" do
+      assert match? {"EUR", 4200, -2}, MoneyProtocol.to_integer(@ex_money)
+      assert match? {"BHD", 42000, -3}, MoneyProtocol.to_integer(@ex_money_bhd)
+    end
+
+    test "to_string" do
+      assert match? {"EUR", "42.00"}, MoneyProtocol.to_string(@ex_money)
+      assert match? {"EUR", "42.13"}, MoneyProtocol.to_string(@ex_money_long)
+      assert match? {"BHD", "42.000"}, MoneyProtocol.to_string(@ex_money_bhd)
     end
   end
 end


### PR DESCRIPTION
* Also implements the new methods for `ex_money` (makes use of the `Cldr.Currency` package).
* See how easy it has become to format the `amount` in MONEI!

We'll remove the implementations once the lib authors implement it in their `master`.