### PR TITLE
[ANet] Corrected use of money protocol and examples 

### DIFF
--- a/test/gateways/authorize_net_test.exs
+++ b/test/gateways/authorize_net_test.exs
@@ -12,7 +12,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   @card %CreditCard {
     number: "5424000000000015",
     month: 12,
-    year: 2020,
+    year: 2099,
     verification_code: 999
   }
 
@@ -23,24 +23,27 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
     verification_code: 123
   }
 
-  @amount %{amount: Decimal.new(20.0), currency: 'USD'}
+  @amount Money.new("2.99", :USD)
 
   @opts [
-    config: @auth,
+    config: auth,
     ref_id: "123456",
-    order: %{invoice_number: "INV-12345", description: "Product Description"}, 
+    order: %{invoice_number: "INV-12345", description: "Product Description"},
     lineitems: %{
       item_id: "1",
       name: "vase",
-      description: "Cannes logo", 
-      quantity: "18", 
-      unit_price: %{amount: Decimal.new(20.0), currency: 'USD'}
-    }
+      description: "Cannes logo",
+      quantity: 18,
+      unit_price: Money.mult!(amount, 18)
+    },
+    tax: %{name: "VAT", amount: Money.new("0.1", :EUR), description: "Value Added Tax"},
+    shipping: %{name: "SAME-DAY-DELIVERY", amount: Money.new("0.56", :EUR), description: "Zen Logistics"},
+    duty: %{name: "import_duty", amount: Money.new("0.25", :EUR), description: "Upon import of goods"}
   ]
   @opts_refund [
     config: @auth,
     ref_id: "123456", 
-    payment: %{card: %{number: "5424000000000015", year: 2020, month: 12}}
+    payment: %{card: %{number: "5424000000000015", year: 2099, month: 12}}
   ]
 
   @opts_store [
@@ -68,12 +71,12 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   @opts_refund [
     config: @auth,
     ref_id: "123456",
-    payment: %{card: %{number: "5424000000000015", year: 2020, month: 12}}
+    payment: %{card: %{number: "5424000000000015", year: 2099, month: 12}}
   ]
   @opts_refund_bad_payment [
     config: @auth,
     ref_id: "123456",
-    payment: %{card: %{number: "123", year: 2020, month: 12}}
+    payment: %{card: %{number: "123", year: 2099, month: 12}}
   ]
   @opts_store [
     config: @auth,

--- a/test/mocks/authorize_net_mock.exs
+++ b/test/mocks/authorize_net_mock.exs
@@ -3,7 +3,7 @@
     # purchase mock response
     def successful_purchase_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>C7HPT1</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>60036553096</transId><refTransID /><transHash>5D6782A03246EE3BAFABE8006E32DE97</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>C7HPT1</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>60036553096</transId><refTransID /><transHash>5D6782A03246EE3BAFABE8006E32DE97</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -21,7 +21,7 @@
 
     def bad_card_purchase_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><ErrorResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XXXXX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><ErrorResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XXXXX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -39,7 +39,7 @@
 
     def bad_amount_purchase_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>5</errorCode><errorText>A valid amount is required.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>5</errorCode><errorText>A valid amount is required.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -58,7 +58,7 @@
     # authorize mock response
     def successful_authorize_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>K6Z0AB</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>60036854582</transId><refTransID /><transHash>A4AD079E22A271D92662CF093CED7A5D</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>K6Z0AB</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>60036854582</transId><refTransID /><transHash>A4AD079E22A271D92662CF093CED7A5D</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -76,7 +76,7 @@
 
     def bad_card_authorize_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><ErrorResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XXXXX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><ErrorResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XXXXX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -94,7 +94,7 @@
 
     def bad_amount_authorize_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>290</errorCode><errorText>There is one or more missing or invalid required fields.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>290</errorCode><errorText>There is one or more missing or invalid required fields.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -114,7 +114,7 @@
 
     def successful_capture_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>4OKD6Y</authCode><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>60036854931</transId><refTransID>60036854931</refTransID><transHash>348C4ECD0F764736B012C4655BFA68EF</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>4OKD6Y</authCode><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>60036854931</transId><refTransID>60036854931</refTransID><transHash>348C4ECD0F764736B012C4655BFA68EF</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -132,7 +132,7 @@
 
     def bad_id_capture do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>A5280E2A6AA1290D451A24286692D1B0</transHash><testRequest>0</testRequest><accountNumber /><accountType /><errors><error><errorCode>33</errorCode><errorText>A valid referenced transaction ID is required.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID /><transHash>A5280E2A6AA1290D451A24286692D1B0</transHash><testRequest>0</testRequest><accountNumber /><accountType /><errors><error><errorCode>33</errorCode><errorText>A valid referenced transaction ID is required.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -151,7 +151,7 @@
     # refund mock response
     def successful_refund_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>60036855661</transId><refTransID>60036752756</refTransID><transHash>169F2381B172A5AA247A01757A3E520A</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>60036855661</transId><refTransID>60036752756</refTransID><transHash>169F2381B172A5AA247A01757A3E520A</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -169,7 +169,7 @@
 
     def bad_card_refund do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><ErrorResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><ErrorResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Error</resultCode><message><code>E00003</code><text>The 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:cardNumber' element is invalid - The value XX is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</text></message></messages></ErrorResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -187,7 +187,7 @@
 
     def debit_less_than_refund do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID>60036752756</refTransID><transHash>A5280E2A6AA1290D451A24286692D1B0</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>55</errorCode><errorText>The sum of credits against the referenced transaction would exceed original debit amount.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID>60036752756</refTransID><transHash>A5280E2A6AA1290D451A24286692D1B0</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><errors><error><errorCode>55</errorCode><errorText>The sum of credits against the referenced transaction would exceed original debit amount.</errorText></error></errors><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -206,7 +206,7 @@
     # void mock response
     def successful_void do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>ZJPVRX</authCode><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>60036855217</transId><refTransID>60036855217</refTransID><transHash>F09A215511891DCEA91B6CC52B9F4E87</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>ZJPVRX</authCode><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>60036855217</transId><refTransID>60036855217</refTransID><transHash>F09A215511891DCEA91B6CC52B9F4E87</transHash><testRequest>0</testRequest><accountNumber>XXXX0015</accountNumber><accountType>MasterCard</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -224,7 +224,7 @@
 
     def void_non_existent_id do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createTransactionResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID>60036855219</refTransID><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber /><accountType /><errors><error><errorCode>16</errorCode><errorText>The transaction cannot be found.</errorText></error></errors><shipTo /><transHashSha2 /></transactionResponse></createTransactionResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><refId>123456</refId><messages><resultCode>Error</resultCode><message><code>E00027</code><text>The transaction was unsuccessful.</text></message></messages><transactionResponse><responseCode>3</responseCode><authCode /><avsResultCode>P</avsResultCode><cvvResultCode /><cavvResultCode /><transId>0</transId><refTransID>60036855219</refTransID><transHash>C7C56F020A2AE2660A87637CD00B4D5C</transHash><testRequest>0</testRequest><accountNumber /><accountType /><errors><error><errorCode>16</errorCode><errorText>The transaction cannot be found.</errorText></error></errors><shipTo /><transHashSha2 /></transactionResponse></createTransactionResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -244,7 +244,7 @@
 
     def successful_store_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createCustomerProfileResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><customerProfileId>1813991490</customerProfileId><customerPaymentProfileIdList><numericString>1808649724</numericString></customerPaymentProfileIdList><customerShippingAddressIdList /><validationDirectResponseList /></createCustomerProfileResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createCustomerProfileResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><customerProfileId>1813991490</customerProfileId><customerPaymentProfileIdList><numericString>1808649724</numericString></customerPaymentProfileIdList><customerShippingAddressIdList /><validationDirectResponseList /></createCustomerProfileResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -262,7 +262,7 @@
     
     def store_without_profile_fields do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createCustomerProfileResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Error</resultCode><message><code>E00041</code><text>One or more fields in the profile must contain a value.</text></message></messages></createCustomerProfileResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createCustomerProfileResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Error</resultCode><message><code>E00041</code><text>One or more fields in the profile must contain a value.</text></message></messages></createCustomerProfileResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -281,7 +281,7 @@
     #unstore mock response
     def successful_unstore_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><deleteCustomerProfileResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages></deleteCustomerProfileResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><deleteCustomerProfileResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages></deleteCustomerProfileResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",
@@ -299,7 +299,7 @@
 
     def customer_payment_profile_success_response do
       {:ok,
-      %HTTPoison.Response{body: "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><createCustomerPaymentProfileResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><customerProfileId>1814012002</customerProfileId><customerPaymentProfileId>1808670005</customerPaymentProfileId><validationDirectResponse>1,1,1,(TESTMODE) This transaction has been approved.,000000,P,0,none,Test transaction for ValidateCustomerPaymentProfile.,1.00,CC,auth_only,none,,,,,,,,,,,email@example.com,,,,,,,,,0.00,0.00,0.00,FALSE,none,EA9FD49A9501D0415FE26BAEF9FD8B2C,,,,,,,,,,,,,XXXX0015,MasterCard,,,,,,,,,,,,,,,,,</validationDirectResponse></createCustomerPaymentProfileResponse>",
+      %HTTPoison.Response{body: ~s{<?xml version="1.0" encoding="utf-8"?><createCustomerPaymentProfileResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><customerProfileId>1814012002</customerProfileId><customerPaymentProfileId>1808670005</customerPaymentProfileId><validationDirectResponse>1,1,1,(TESTMODE) This transaction has been approved.,000000,P,0,none,Test transaction for ValidateCustomerPaymentProfile.,1.00,CC,auth_only,none,,,,,,,,,,,email@example.com,,,,,,,,,0.00,0.00,0.00,FALSE,none,EA9FD49A9501D0415FE26BAEF9FD8B2C,,,,,,,,,,,,,XXXX0015,MasterCard,,,,,,,,,,,,,,,,,</validationDirectResponse></createCustomerPaymentProfileResponse>},
        headers: [{"Cache-Control", "private"},
         {"Content-Type", "application/xml; charset=utf-8"},
         {"X-OPNET-Transaction-Trace",


### PR DESCRIPTION
* Adds a new Response field: authorization.
    - It is set to `["transactionResponse"]["transId"]`
* Uses `Gringotts.Money.to_string` instead of converting to lossy Float
* doc examples updated (authorize, capture, purchase)
* Improved all docs, http links and made most lines fit 80 columns
* Ran the elixir 1.6 formatter
    - Used the `~s` sigil in mocks
    - Also removed an invisible Unicode codepoint from mock strings



Fixes #90 and Fixes #91