### PR TITLE
Adds changelog, contributing guide and improves mix task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# [`v1.1.0-alpha`][tag-1_1_0_alpha]
+
+## Added
+
+* [`ISS`][iss#80] [`PR`][pr#78]
+Add a `Mix` task that generates a barebones gateway implementation and test suite.
+
+## Changed
+
+* [`ISS`][iss#62] [`PR`][pr#71] [`PR`][pr#86]
+Deprecate use of `floats` for money amounts, introduce the `Gringotts.Money` protocol.
+
+[iss#62]: https://github.com/aviabird/gringotts/issues/62
+[iss#80]: https://github.com/aviabird/gringotts/issues/80
+
+[pr#71]: https://github.com/aviabird/gringotts/pulls/71
+[pr#78]:https://github.com/aviabird/gringotts/pulls/78
+[pr#86]:https://github.com/aviabird/gringotts/pulls/86
+
+# [`v1.0.2`][tag-1_0_2]
+
+## Added
+
+* New Gateway: **Trexle**
+
+## Changed
+
+* Reduced arity of public API calls by 1
+  - No need to pass the name of the `worker` as argument.
+
+# [`v1.0.1`][tag-1_0_1]
+
+## Added
+
+* Improved documentation - made consistent accross gateways
+* Improved test coverage
+
+# [`v1.0.0`][tag-1_0_0]
+
+* Initial public API release.
+* Single worker architecture, config fetched from `config.exs`
+* Supported Gateways:
+  - Stripe
+  - MONEI
+  - Paymill
+  - WireCard
+  - CAMS
+
+[tag-1_1_0_alpha]: https://github.com/aviabird/gringotts/releases/tag/v1.1.0-alpha
+[tag-1_0_2]: https://github.com/aviabird/gringotts/releases/tag/v1.0.2
+[tag-1_0_1]: https://github.com/aviabird/gringotts/releases/tag/v1.0.1
+[tag-1_0_0]: https://github.com/aviabird/gringotts/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to [`gringotts`][gringotts]
+
+There are many ways to contribute to `gringotts`,
+
+1. [Integrate a new Payment Gateway][wiki-new-gateway].
+2. Expanding the feature coverage of (partially) supported gateways.
+3. Moving forward on the [roadmap][roadmap] or on tasks being tracked in the
+   [milestones][milestones].
+
+We manage our development using [milestones][milestones] and issues so if you're
+a first time contributor, look out for the [`good first issue`][first-issues]
+and the [`hotlist: community-help`][ch-issues] labels on the [issues][issues]
+page.
+
+The docs are hosted on [hexdocs.pm][hexdocs] and are updated for each
+release. **You must build the docs locally using `mix docs` to get the bleeding
+edge developer docs.**
+
+The article on [Gringott's Architecture][wiki-arch] explains how API calls are
+processed.
+
+:exclamation: ***Please base your work on the `dev` branch.***
+
+[roadmap]: https://github.com/aviabird/gringotts/wiki/Roadmap
+[wiki-arch]: https://github.com/aviabird/gringotts/wiki/Architecture
+
+### PR submission checklist
+
+Each PR should introduce a *focussed set of changes*, and ideally not span over
+unrelated modules.
+
+* [ ] Run the edited files through [credo][credo] and the Elixir
+      [formatter][hashrocket-formatter] (new in `v1.6`).
+* [ ] Check the test coverage by running `mix coveralls`. 100% coverage is not
+      strictly required.
+* [ ] If the PR introduces a new Gateway or just Gateway specific changes,
+      please format the title like so,\
+      `[<gateway-name>] <the-title>`
+
+[gringotts]: https://github.com/aviabird/gringotts
+[milestones]: https://github.com/aviabird/gringotts/milestones
+[issues]: https://github.com/aviabird/gringotts/issues
+[first-issues]: https://github.com/aviabird/gringotts/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue"
+[ch-issues]: https://github.com/aviabird/gringotts/issues?q=is%3Aissue+is%3Aopen+label%3A"hotfix%3A+community-help"
+[hexdocs]: https://hexdocs.pm/gringotts
+[credo]: https://github.com/rrrene/credo
+[hashrocket-formatter]: https://hashrocket.com/blog/posts/format-your-elixir-code-now
+
+# Style Guidelines
+
+We use [`credo`][credo] and the elixir formatter for consistent style, so please
+use them!
+
+## General Rules
+
+* Keep line length below 120 characters.
+* Complex anonymous functions should be extracted into named functions.
+* One line functions, should only take up one line!
+* Pipes are great, but don't use them, if they are less readable than brackets
+  then drop the pipe!
+
+## Writing documentation
+
+All our docs are inline and built using [`ExDocs`][exdocs]. Please take a look
+at how the docs are structured for the [MONEI gateway][src-monei] for
+inspiration.
+
+[exdocs]: https://github.com/elixir-lang/ex_doc
+[src-monei]: https://github.com/aviabird/gringotts/blob/dev/lib/gringotts/gateways/monei.ex
+
+## Writing test cases
+
+> This is WIP.
+
+`gringotts` has mock and integration tests. We have currently used
+[`bypass`][bypass] and [`mock`][mock] for mock tests, but we don't recommed
+using `mock` as it constrains tests to run serially. Use [`mox`][mox] instead.\
+Take a look at [MONEI's mock tests][src-monei-tests] for inspiration.
+
+--------------------------------------------------------------------------------
+
+> **Where to next?**
+> Wanna add a new gateway? Head to our [guide][wiki-new-gateway] for that.
+
+[wiki-new-gateway]: https://github.com/aviabird/gringotts/wiki/Adding-a-new-Gateway
+[bypass]: https://github.com/pspdfkit-labs/bypass
+[mock]: https://github.com/jjh42/mock
+[mox]: https://github.com/plataformatec/mox
+[src-monei-tests]: https://github.com/aviabird/gringotts/blob/dev/test/gateways/monei_test.exs
+[gringotts]: https://github.com/aviabird/gringotts
+[docs]: https://hexdocs.pm/gringotts/Gringotts.html

--- a/README.md
+++ b/README.md
@@ -5,24 +5,24 @@
 </p>
 
 <p align="center">
-  Gringotts is a payment processing library in Elixir integrating various payment gateways, this draws motivation for shopify's <a href="https://github.com/activemerchant/active_merchant">activemerchant</a> gem. Checkout the <a href="https://gringottspay.herokuapp.com/" target="_">Demo</a> here.
+  Gringotts is a payment processing library in Elixir integrating various payment gateways, drawing motivation for Shopify's <a href="https://github.com/activemerchant/active_merchant"><code>activemerchant</code></a> gem. Checkout the <a href="https://gringottspay.herokuapp.com/" target="_">Demo</a> here.
 </p>
 <p align="center">
  <a href="https://travis-ci.org/aviabird/gringotts"><img src="https://travis-ci.org/aviabird/gringotts.svg?branch=master"  alt='Build Status' /></a>  <a href='https://coveralls.io/github/aviabird/gringotts?branch=master'><img src='https://coveralls.io/repos/github/aviabird/gringotts/badge.svg?branch=master' alt='Coverage Status' /></a> <a href=""><img src="https://img.shields.io/hexpm/v/gringotts.svg"/></a> <a href="https://inch-ci.org/github/aviabird/gringotts"><img src="http://inch-ci.org/github/aviabird/gringotts.svg?branch=master" alt="Docs coverage"></img></a> <a href="https://gitter.im/aviabird/gringotts"><img src="https://badges.gitter.im/aviabird/gringotts.svg"/></a>
  <a href="https://www.codetriage.com/aviabird/gringotts"><img src="https://www.codetriage.com/aviabird/gringotts/badges/users.svg" alt='Help Contribute to Open Source' /></a>
 </p>
 
-A simple and unified API to access dozens of different payment
-gateways with very different internal APIs is what Gringotts has to offer you.
+Gringotts offers a **simple and unified API** to access dozens of different payment
+gateways with very different APIs, response schemas, documentation and jargon.
 
 ## Installation
 
-### From hex.pm
+### From [`hex.pm`][hexpm]
 
-Make the following changes to the `mix.exs` file.
-
-Add gringotts to the list of dependencies.
+Add `gringotts` to the list of dependencies of your application.
 ```elixir
+# your mix.exs
+
 def deps do
   [
     {:gringotts, "~> 1.0"},
@@ -35,22 +35,30 @@ end
 
 ## Usage
 
-This simple example demonstrates how a purchase can be made using a person's credit card details.
+This simple example demonstrates how a `purchase` can be made using a sample
+credit card using the [MONEI][monei] gateway.
 
-Add configs in `config/config.exs` file.
+One must "register" their account with `gringotts` ie, put all the
+authentication details in the Application config. Usually via
+`config/config.exs`
 
 ```elixir
+# config/config.exs
+
 config :gringotts, Gringotts.Gateways.Monei,
     userId: "your_secret_user_id",
     password: "your_secret_password",
     entityId: "your_secret_channel_id"
 ```
 
-Copy and paste this code in your module
+Copy and paste this code in a module or an `IEx` session
 
 ```elixir
 alias Gringotts.Gateways.Monei
 alias Gringotts.{CreditCard}
+
+# a fake sample card that will work now because the Gateway is by default
+# in "test" mode.
 
 card = %CreditCard{
   first_name: "Harry",
@@ -61,9 +69,10 @@ card = %CreditCard{
   brand: "VISA"
 }
 
+# a sum of $42
 amount = Money.new(42, :USD)
 
-case Gringotts.purchase(Monei, amount, card, opts) do
+case Gringotts.purchase(Monei, amount, card) do
   {:ok,    %{id: id}} ->
     IO.puts("Payment authorized, reference token: '#{id}'")
 
@@ -71,6 +80,9 @@ case Gringotts.purchase(Monei, amount, card, opts) do
     IO.puts("Error: #{error}\nRaw:\n#{raw_response}")
 end
 ```
+
+[hexpm]: https://hex.pm/packages/gringotts
+[monei]: http://www.monei.net
 
 ## Supported Gateways
 
@@ -95,9 +107,29 @@ end
 
 ## Road Map
 
-- Support more gateways on an on-going basis.
-- Each gateway request is hosted in a worker process and supervised.
+Apart from supporting more and more gateways, we also keep a somewhat detailed
+plan for the future on our [wiki][roadmap].
+
+## FAQ
+
+#### 1. What's with the name? "Gringotts"?
+
+Gringotts has a nice ring to it. Also [this][reason].
+
+#### 2. What is the worker doing in the middle?
+
+We wanted to "supervise" our payments, and power utilities to process recurring
+payments, subscriptions with it. But yes, as of now, it is a bottle neck and
+unnecessary.
+
+It's slated to be removed in [`v2.0.0`][milestone-2_0_0_alpha] and any supervised / async /
+parallel work can be explicitly managed via native elixir constructs.
+
+[milestone-2_0_0_alpha]: https://github.com/aviabird/gringotts/milestone/3
+[reason]: http://harrypotter.wikia.com/wiki/Gringotts
 
 ## License
 
 MIT
+
+[roadmap]: https://github.com/aviabird/gringotts/wiki/Roadmap

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -89,18 +89,16 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       that gives you a pre-configured sample app ready-to-go.
         + You could use the same config or update it the with your "secrets"
           [above](#module-configuring-your-authorizenet-account-at-gringotts).
-  2. Run an `iex` session with `iex -S mix` and add some variable bindings and
-     aliases to it (to save some time):
+  
+  2. To save a lot of time, create a [`.iex.exs`][iex-docs] file as shown in
+     [this gist][authorize_net.iex.exs] to introduce a set of handy bindings and
+     aliases.
 
-  ```
-  iex> alias Gringotts.{Response, CreditCard, Gateways.AuthorizeNet}
-  iex> amount = Money.new(20, :USD)
-  iex> card = %CreditCard{number: "5424000000000015", year: 2099, month: 12, verification_code: "999"}
-  ```
-
-  We'll be using these in the examples below.
+  We'll be using these bindings in the examples below.
 
   [example-repo]: https://github.com/aviabird/gringotts_example
+  [iex-docs]: https://hexdocs.pm/iex/IEx.html#module-the-iex-exs-file
+  [authorize_net.iex.exs]: https://gist.github.com/oyeb/b1030058bda1fa9a3d81f1cf30723695
   [gs]: https://github.com/aviabird/gringotts/wiki
   """
 
@@ -465,7 +463,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
     |> element(%{xmlns: @aut_net_namespace}, [
       add_merchant_auth(opts[:config]),
       add_order_id(opts),
-      add_capture_transaction_request(amount, id, transaction_type, opts)
+      add_capture_transaction_request(amount, id, transaction_type)
     ])
     |> generate(format: :none)
   end
@@ -561,7 +559,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       add_transaction_type(transaction_type),
       add_amount(amount),
       add_payment_source(payment),
-      add_invoice(transaction_type, opts),
+      add_invoice(opts),
       add_tax_fields(opts),
       add_duty_fields(opts),
       add_shipping_fields(opts),
@@ -570,7 +568,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
     ])
   end
 
-  defp add_capture_transaction_request(amount, id, transaction_type, opts) do
+  defp add_capture_transaction_request(amount, id, transaction_type) do
     element(:transactionRequest, [
       add_transaction_type(transaction_type),
       add_amount(amount),
@@ -626,7 +624,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
     ])
   end
 
-  defp add_invoice(transactionType, opts) do
+  defp add_invoice(opts) do
     element([
       element(:order, [
         element(:invoiceNumber, opts[:order][:invoice_number]),

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -94,7 +94,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
   ```
   iex> alias Gringotts.{Response, CreditCard, Gateways.AuthorizeNet}
-  iex> amount = Money.new(20, :USD}
+  iex> amount = Money.new(20, :USD)
   iex> card = %CreditCard{number: "5424000000000015", year: 2099, month: 12, verification_code: "999"}
   ```
 
@@ -170,7 +170,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
 
   ## Example
-      iex> amount = Money.new(20, :USD}
+      iex> amount = Money.new(20, :USD)
       iex> opts = [
         ref_id: "123456",
         order: %{invoice_number: "INV-12345", description: "Product Description"},
@@ -230,7 +230,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
 
   ## Example
-      iex> amount = Money.new(20, :USD}
+      iex> amount = Money.new(20, :USD)
       iex> opts = [
         ref_id: "123456",
         order: %{invoice_number: "INV-12345", description: "Product Description"},
@@ -280,7 +280,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> opts = [
         ref_id: "123456"
       ]
-      iex> amount = Money.new(20, :USD}
+      iex> amount = Money.new(20, :USD)
       iex> id = "123456"
       iex> result = Gringotts.capture(Gringotts.Gateways.AuthorizeNet, id, amount, opts)
   """
@@ -310,7 +310,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
         ref_id: "123456"
       ]
       iex> id = "123456"
-      iex> amount = Money.new(20, :USD}
+      iex> amount = Money.new(20, :USD)
       iex> result = Gringotts.refund(Gringotts.Gateways.AuthorizeNet, amount, id, opts)
   """
   @spec refund(Money.t(), String.t(), Keyword.t()) :: {:ok | :error, Response.t()}

--- a/lib/gringotts/gateways/bogus.ex
+++ b/lib/gringotts/gateways/bogus.ex
@@ -1,4 +1,6 @@
 defmodule Gringotts.Gateways.Bogus do
+  @moduledoc false
+  
   use Gringotts.Gateways.Base
 
   alias Gringotts.{
@@ -6,36 +8,29 @@ defmodule Gringotts.Gateways.Bogus do
     Response
   }
 
+  @some_authorization_id "14a62fff80f24a25f775eeb33624bbb3"
+  
   def authorize(_amount, _card_or_id, _opts),
     do: success()
 
   def purchase(_amount, _card_or_id, _opts),
     do: success()
 
-  def capture(id, amount, _opts),
-    do: success(id)
-
-  def void(id, _opts),
-    do: success(id)
-
-  def refund(_amount, id, _opts),
-    do: success(id)
-
-  def store(_card = %CreditCard{}, _opts),
+  def capture(_id, _amount, _opts),
     do: success()
 
-  def unstore(customer_id, _opts),
-    do: success(customer_id)
+  def void(_id, _opts),
+    do: success()
+
+  def refund(_amount, _id, _opts),
+    do: success()
+
+  def store(%CreditCard{} = _card, _opts),
+    do: success()
+
+  def unstore(_customer_id, _opts),
+    do: success()
 
   defp success,
-    do: {:ok, Response.success(id: random_string())}
-
-  defp success(id),
-    do: {:ok, Response.success(id: id)}
-
-  defp random_string(length \\ 10),
-    do: 1..length |> Enum.map(&random_char/1) |> Enum.join
-
-  defp random_char(_),
-    do: to_string(:rand.uniform(9))
+    do: {:ok, Response.success(id: @some_authorization_id)}
 end

--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -92,7 +92,7 @@ defmodule Gringotts.Gateways.Cams do
                           month: 12,
                           verification_code: "999",
                           brand: "VISA"}
-  iex> money = %{value: Decimal.new(20), currency: "USD"}
+  iex> money = Money.new(20, :USD)
   ```
   We'll be using these in the examples below.
 
@@ -164,7 +164,7 @@ defmodule Gringotts.Gateways.Cams do
                           month: 12,
                           verification_code: "999",
                           brand: "VISA"}
-  iex> money = %{value: Decimal.new(20), currency: "USD"}
+  iex> money = Money.new(20, :USD)
   iex> {:ok, auth_result} = Gringotts.authorize(Gringotts.Gateways.Cams, money, card)
   ```
   """
@@ -209,7 +209,7 @@ defmodule Gringotts.Gateways.Cams do
                           month: 12,
                           verification_code: "999",
                           brand: "VISA"}
-  iex> money = %{value: Decimal.new(10), currency: "USD"}
+  iex> money = Money.new(10, :USD)
   iex> authorization = auth_result.authorization
   # authorization = "some_authorization_transaction_id"
   iex> {:ok, capture_result} = Gringotts.capture(Gringotts.Gateways.Cams, money, authorization)
@@ -247,7 +247,7 @@ defmodule Gringotts.Gateways.Cams do
                           month: 12,
                           verification_code: "999",
                           brand: "VISA"}
-  iex> money = %{value: Decimal.new(20), currency: "USD"}
+  iex> money = Money.new(20, :USD)
   iex> Gringotts.purchase(Gringotts.Gateways.Cams, money, card)
   ```
   """
@@ -279,7 +279,7 @@ defmodule Gringotts.Gateways.Cams do
   ```
   iex> capture_id = capture_result.authorization
   # capture_id = "some_capture_transaction_id"
-  iex> money = %{value: Decimal.new(20), currency: "USD"}
+  iex> money = Money.new(20, :USD)
   iex> Gringotts.refund(Gringotts.Gateways.Cams, money, capture_id)
   ```
   """

--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -38,13 +38,13 @@ defmodule Gringotts.Gateways.Cams do
     this is important to you.
 
   [issues]: https://github.com/aviabird/gringotts/issues/new
-  
+
   ### Schema
 
   * `billing_address` is a `map` from `atoms` to `String.t`, and can include any
     of the keys from:
     `:name, :address1, :address2, :company, :city, :state, :zip, :country, :phone, :fax]`
-  
+
   ## Registering your CAMS account at `Gringotts`
 
   | Config parameter | CAMS secret   |
@@ -81,26 +81,21 @@ defmodule Gringotts.Gateways.Cams do
         you get after [registering with
         CAMS](#module-registering-your-cams-account-at-gringotts).
 
-  2. Run an `iex` session with `iex -S mix` and add some variable bindings and
-  aliases to it (to save some time):
-  ```
-  iex> alias Gringotts.{Response, CreditCard, Gateways.Cams}
-  iex> card = %CreditCard{first_name: "Harry",
-                          last_name: "Potter",
-                          number: "4111111111111111",
-                          year: 2099,
-                          month: 12,
-                          verification_code: "999",
-                          brand: "VISA"}
-  iex> money = Money.new(20, :USD)
-  ```
-  We'll be using these in the examples below.
+  2. To save a lot of time, create a [`.iex.exs`][iex-docs] file as shown in
+     [this gist][cams.iex.exs] to introduce a set of handy bindings and
+     aliases.
+
+  We'll be using these bindings in the examples below.
+
+  [example-repo]: https://github.com/aviabird/gringotts_example
+  [iex-docs]: https://hexdocs.pm/iex/IEx.html#module-the-iex-exs-file
+  [cams.iex.exs]: https://gist.github.com/oyeb/9a299df95cc13a87324e321faca5c9b8
 
   ## Integrating with phoenix
 
   Refer the [GringottsPay][gpay-heroku-cams] website for an example of how to
   integrate CAMS with phoenix. The source is available [here][gpay-repo].
-  
+
   [gpay-repo]: https://github.com/aviabird/gringotts_payment
   [gpay-heroku-cams]: http://gringottspay.herokuapp.com/cams
 

--- a/lib/gringotts/gateways/monei.ex
+++ b/lib/gringotts/gateways/monei.ex
@@ -126,56 +126,15 @@ defmodule Gringotts.Gateways.Monei do
           that you see in `Dashboard > Sub-accounts` as described
           [above](#module-registering-your-monei-account-at-gringotts).
 
-  2. Run an `iex` session with `iex -S mix` and add some variable bindings and
-  aliases to it (to save some time):
-  ```
-  iex> alias Gringotts.{Response, CreditCard, Gateways.Monei}
-  iex> amount = Money.new(42, :USD)
-  iex> card = %CreditCard{first_name: "Harry",
-                          last_name: "Potter",
-                          number: "4200000000000000",
-                          year: 2099, month: 12,
-                          verification_code: "123",
-                          brand: "VISA"}
-  iex> customer = %{"givenName": "Harry",
-                    "surname": "Potter",
-                    "merchantCustomerId": "the_boy_who_lived",
-                    "sex": "M",
-                    "birthDate": "1980-07-31",
-                    "mobile": "+15252525252",
-                    "email": "masterofdeath@ministryofmagic.gov",
-                    "ip": "127.0.0.1",
-                    "status": "NEW"}
-  iex> merchant = %{"name": "Ollivanders",
-                    "city": "South Side",
-                    "street": "Diagon Alley",
-                    "state": "London",
-                    "country": "GB",
-                    "submerchantId": "Makers of Fine Wands since 382 B.C."}
-  iex> billing = %{"street1": "301, Gryffindor",
-                   "street2": "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
-                   "city": "Highlands",
-                   "state": "Scotland",
-                   "country": "GB"}
-  iex> shipping = %{"street1": "301, Gryffindor",
-                    "street2": "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
-                    "city": "Highlands",
-                    "state": "Scotland",
-                    "country": "GB",
-                    "method": "SAME_DAY_SERVICE",
-                    "comment": "For our valued customer, Mr. Potter"}
-  iex> opts = [customer: customer,
-               merchant: merchant,
-               billing: billing,
-               shipping: shipping,
-               category: "EC",
-               custom: %{"voldemort": "he who must not be named"},
-               register: true]
-  ```
+  2. To save a lot of time, create a [`.iex.exs`][iex-docs] file as shown in
+     [this gist][monei.iex.exs] to introduce a set of handy bindings and
+     aliases.
 
-  We'll be using these in the examples below.
+  We'll be using these bindings in the examples below.
 
   [example-repo]: https://github.com/aviabird/gringotts_example
+  [iex-docs]: https://hexdocs.pm/iex/IEx.html#module-the-iex-exs-file
+  [monei.iex.exs]: https://gist.github.com/oyeb/a2e2ac5986cc90a12a6136f6bf1357e5
 
   ## TODO
 

--- a/lib/gringotts/gateways/monei.ex
+++ b/lib/gringotts/gateways/monei.ex
@@ -130,7 +130,7 @@ defmodule Gringotts.Gateways.Monei do
   aliases to it (to save some time):
   ```
   iex> alias Gringotts.{Response, CreditCard, Gateways.Monei}
-  iex> amount = %{value: Decimal.new(42), currency: "USD"}
+  iex> amount = Money.new(42, :USD)
   iex> card = %CreditCard{first_name: "Harry",
                           last_name: "Potter",
                           number: "4200000000000000",
@@ -251,7 +251,7 @@ defmodule Gringotts.Gateways.Monei do
   The following example shows how one would (pre) authorize a payment of $42 on
   a sample `card`.
 
-      iex> amount = %{value: Decimal.new(42), currency: "USD"}
+      iex> amount = Money.new(42, :USD)
       iex> card = %Gringotts.CreditCard{first_name: "Harry", last_name: "Potter", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
       iex> {:ok, auth_result} = Gringotts.authorize(Gringotts.Gateways.Monei, amount, card, opts)
       iex> auth_result.id # This is the authorization ID
@@ -289,7 +289,7 @@ defmodule Gringotts.Gateways.Monei do
   The following example shows how one would (partially) capture a previously
   authorized a payment worth $35 by referencing the obtained authorization `id`.
 
-      iex> amount = %{value: Decimal.new(35), currency: "USD"}
+      iex> amount = Money.new(35, :USD)
       iex> {:ok, capture_result} = Gringotts.capture(Gringotts.Gateways.Monei, amount, auth_result.id, opts)
   """
   @spec capture(String.t(), Money.t(), keyword) :: {:ok | :error, Response.t()}
@@ -323,7 +323,7 @@ defmodule Gringotts.Gateways.Monei do
   The following example shows how one would process a payment worth $42 in
   one-shot, without (pre) authorization.
 
-      iex> amount = %{value: Decimal.new(42), currency: "USD"}
+      iex> amount = Money.new(42, :USD)
       iex> card = %Gringotts.CreditCard{first_name: "Harry", last_name: "Potter", number: "4200000000000000", year: 2099, month: 12, verification_code:  "123", brand: "VISA"}
       iex> {:ok, purchase_result} = Gringotts.purchase(Gringotts.Gateways.Monei, amount, card, opts)
       iex> purchase_result.token # This is the registration ID/token
@@ -357,7 +357,7 @@ defmodule Gringotts.Gateways.Monei do
   The following example shows how one would (completely) refund a previous
   purchase (and similarily for captures).
 
-      iex> amount = %{value: Decimal.new(42), currency: "USD"}
+      iex> amount = Money.new(42, :USD)
       iex> {:ok, refund_result} = Gringotts.refund(Gringotts.Gateways.Monei, purchase_result.id, amount)
   """
   @spec refund(Money.t(), String.t(), keyword) :: {:ok | :error, Response.t()}

--- a/lib/gringotts/gateways/trexle.ex
+++ b/lib/gringotts/gateways/trexle.ex
@@ -66,35 +66,16 @@ defmodule Gringotts.Gateways.Trexle do
           that as described
           [above](#module-registering-your-trexle-account-at-gringotts).
 
-  2. Run an `iex` session with `iex -S mix` and add some variable bindings and
-  aliases to it (to save some time):
-  ```
-  iex> alias Gringotts.{Response, CreditCard, Gateways.Trexle}
-  iex> card = %CreditCard{
-               first_name: "Harry",
-               last_name: "Potter",
-               number: "4200000000000000",
-               year: 2099, month: 12,
-               verification_code: "123",
-               brand: "VISA"}
-  iex> address = %Address{
-                  street1: "301, Gryffindor",
-                  street2: "Hogwarts School of Witchcraft and Wizardry, Hogwarts Castle",
-                  city: "Highlands",
-                  region: "SL",
-                  country: "GB",
-                  postal_code: "11111",
-                  phone: "(555)555-5555"}
-  iex> options = [email: "masterofdeath@ministryofmagic.gov",
-                  ip_address: "127.0.0.1",
-                  billing_address: address,
-                  description: "For our valued customer, Mr. Potter"]
-  ```
+  2. To save a lot of time, create a [`.iex.exs`][iex-docs] file as shown in
+     [this gist][trexle.iex.exs] to introduce a set of handy bindings and
+     aliases.
 
-  We'll be using these in the examples below.
+  We'll be using these bindings in the examples below.
 
   [example-repo]: https://github.com/aviabird/gringotts_example
-  [gs]: #
+  [iex-docs]: https://hexdocs.pm/iex/IEx.html#module-the-iex-exs-file
+  [trexle.iex.exs]: https://gist.github.com/oyeb/055f40e9ad4102f5480febd2cfa00787
+  [gs]: https://github.com/aviabird/gringotts/wiki
   """
 
   @base_url "https://core.trexle.com/api/v1/"

--- a/lib/gringotts/gateways/trexle.ex
+++ b/lib/gringotts/gateways/trexle.ex
@@ -120,7 +120,7 @@ defmodule Gringotts.Gateways.Trexle do
   a sample `card`.
 
   ```
-  iex> amount = %{value: Decimal.new(100),currency: "USD")
+  iex> amount = Money.new(10, :USD)
   iex> card = %CreditCard{
                first_name: "Harry",
                last_name: "Potter",
@@ -170,7 +170,7 @@ defmodule Gringotts.Gateways.Trexle do
   authorized a payment worth $10 by referencing the obtained `charge_token`.
 
   ```
-  iex> amount = %{value: Decimal.new(100),currency: "USD")
+  iex> amount = Money.new(10, :USD)
   iex> token = "some-real-token"
   iex> Gringotts.capture(Gringotts.Gateways.Trexle, token, amount)
   ```
@@ -194,7 +194,7 @@ defmodule Gringotts.Gateways.Trexle do
   one-shot, without (pre) authorization.
 
   ```
-  iex> amount = %{value: Decimal.new(100),currency: "USD")
+  iex> amount = Money.new(10, :USD)
   iex> card = %CreditCard{
                first_name: "Harry",
                last_name: "Potter",
@@ -242,7 +242,7 @@ defmodule Gringotts.Gateways.Trexle do
   `purchase/3` (and similarily for `capture/3`s).
 
   ```
-  iex> amount = %{value: Decimal.new(100),currency: "USD")
+  iex> amount = Money.new(10, :USD)
   iex> token = "some-real-token"
   iex> Gringotts.refund(Gringotts.Gateways.Trexle, amount, token)
   ```

--- a/lib/mix/new.ex
+++ b/lib/mix/new.ex
@@ -48,7 +48,7 @@ Comma separated list of required configuration keys:
 > }
 
   def run(args) do
-    {key_list, [name], []} =
+    {key_list, name, []} =
       OptionParser.parse(
         args,
         switches: [module: :string, url: :string, file: :string],
@@ -58,12 +58,16 @@ Comma separated list of required configuration keys:
     Mix.Shell.IO.info("Generating barebones implementation for #{name}.")
     Mix.Shell.IO.info("Hit enter to select the suggestion.")
 
-    module_suggestion = name |> String.split |> Enum.map(&String.capitalize(&1)) |> Enum.join("")
+    module_suggestion =
+      name |> String.split() |> Enum.map(&String.capitalize(&1)) |> Enum.join("")
+
     module_name =
       case Keyword.fetch(key_list, :module) do
         :error ->
           prompt_with_suggestion("\nModule name", module_suggestion)
-        {:ok, mod_name} -> mod_name
+
+        {:ok, mod_name} ->
+          mod_name
       end
 
     url =
@@ -71,7 +75,7 @@ Comma separated list of required configuration keys:
         :error ->
           prompt_with_suggestion(
             "\nHomepage URL",
-            "https://www.#{String.Casing.downcase(module_suggestion)}.com"
+            "https://www.#{String.downcase(module_suggestion)}.com"
           )
 
         {:ok, url} ->
@@ -86,11 +90,13 @@ Comma separated list of required configuration keys:
         {:ok, filename} ->
           filename
       end
+
     file_base_name = String.slice(file_name, 0..-4)
-    
+
     required_keys =
       case Mix.Shell.IO.prompt(@long_msg) |> String.trim() do
-        "" -> []
+        "" ->
+          []
 
         keys ->
           String.split(keys, ",") |> Enum.map(&String.trim(&1)) |> Enum.map(&String.to_atom(&1))

--- a/mix.exs
+++ b/mix.exs
@@ -58,16 +58,16 @@ defmodule Gringotts.Mixfile do
       {:ex_money, "~> 1.1.0", only: [:dev, :test], optional: true},
 
       # docs and tests
-      {:ex_doc, "~> 0.16", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.18", only: :dev, runtime: false},
       {:mock, "~> 0.3.0", only: :test},
       {:bypass, "~> 0.8", only: :test},
-      {:excoveralls, "~> 0.7", only: :test},
+      {:excoveralls, "~> 0.8", only: :test},
 
       # various analyses tools
       {:credo, "~> 0.3", only: [:dev, :test]},
       {:inch_ex, "~> 0.5", only: :docs},
       {:dialyxir, "~> 0.3", only: :dev},
-      {:timex, "~> 3.1"}
+      {:timex, "~> 3.2"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"abnf2": {:hex, :abnf2, "0.1.2", "6f8792b8ac3288dba5fc889c2bceae9fe78f74e1a7b36bea9726ffaa9d7bef95", [:mix], [], "hexpm"},
+%{
+  "abnf2": {:hex, :abnf2, "0.1.2", "6f8792b8ac3288dba5fc889c2bceae9fe78f74e1a7b36bea9726ffaa9d7bef95", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "bypass": {:hex, :bypass, "0.8.1", "16d409e05530ece4a72fabcf021a3e5c7e15dcc77f911423196a0c551f2a15ca", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
@@ -17,8 +18,8 @@
   "ex_money": {:hex, :ex_money, "1.1.2", "4336192f1ac263900dfb4f63c1f71bc36a7cdee5d900e81937d3213be3360f9f", [:mix], [{:decimal, "~> 1.4", [hex: :decimal, repo: "hexpm", optional: false]}, {:ecto, "~> 2.1", [hex: :ecto, repo: "hexpm", optional: true]}, {:ex_cldr, "~> 1.0", [hex: :ex_cldr, repo: "hexpm", optional: false]}, {:ex_cldr_numbers, "~> 1.0", [hex: :ex_cldr_numbers, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.8.0", "99d2691d3edf8612f128be3f9869c4d44b91c67cec92186ce49470ae7a7404cf", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
-  "gettext": {:hex, :gettext, "0.14.0", "1a019a2e51d5ad3d126efe166dcdf6563768e5d06c32a99ad2281a1fa94b4c72", [:mix], [], "hexpm"},
-  "hackney": {:hex, :hackney, "1.10.1", "c38d0ca52ea80254936a32c45bb7eb414e7a96a521b4ce76d00a69753b157f21", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "gettext": {:hex, :gettext, "0.15.0", "40a2b8ce33a80ced7727e36768499fc9286881c43ebafccae6bab731e2b2b8ce", [:mix], [], "hexpm"},
+  "hackney": {:hex, :hackney, "1.11.0", "4951ee019df102492dabba66a09e305f61919a8a183a7860236c0fde586134b6", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
@@ -32,7 +33,8 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "timex": {:hex, :timex, "3.1.25", "6002dae5432f749d1c93e2cd103eb73cecb53e50d2c885349e8e4146fc96bd44", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "timex": {:hex, :timex, "3.2.1", "639975eac45c4c08c2dbf7fc53033c313ff1f94fad9282af03619a3826493612", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "xml_builder": {:hex, :xml_builder, "2.1.0", "c249d5339427c13cae11e9d9d0e8b40d25d228b9ecc54029f24017385e60280b", [:mix], [], "hexpm"}}
+  "xml_builder": {:hex, :xml_builder, "2.1.0", "c249d5339427c13cae11e9d9d0e8b40d25d228b9ecc54029f24017385e60280b", [:mix], [], "hexpm"},
+}

--- a/templates/mock_response.eex
+++ b/templates/mock_response.eex
@@ -1,6 +1,6 @@
 defmodule Gringotts.Gateways.<%= gateway_module <> "Mock"%> do
 
-  # The module should include mock responses for test cases in <%= mock_test_filename <> ".exs"%>.
+  # The module should include mock responses for test cases in <%= mock_test_filename %>.
   # e.g. 
   # def successful_purchase do 
   #  {:ok, %HTTPoison.Response{body: ~s[{data: "successful_purchase"}]}

--- a/templates/test.eex
+++ b/templates/test.eex
@@ -2,13 +2,13 @@ defmodule Gringotts.Gateways.<%= gateway_module <> "Test" %> do
   # The file contains mocked tests for <%= gateway_module%>
   
   # We recommend using [mock][1] for this, you can place the mock responses from
-  # the Gateway in `test/mocks/<%= mock_response_filename%>.exs` file, which has also been
+  # the Gateway in `test/mocks/<%= mock_response_filename %>` file, which has also been
   # generated for you.
   #
   # [1]: https://github.com/jjh42/mock
   
   # Load the mock response file before running the tests.
-  Code.require_file "../mocks/<%= mock_response_filename <> ".exs"%>", __DIR__
+  Code.require_file "../mocks/<%= mock_response_filename %>", __DIR__
   
   use ExUnit.Case, async: false
   alias Gringotts.Gateways.<%= gateway_module%>

--- a/test/gateways/bogus_test.exs
+++ b/test/gateways/bogus_test.exs
@@ -4,9 +4,12 @@ defmodule Gringotts.Gateways.BogusTest do
   alias Gringotts.Response
   alias Gringotts.Gateways.Bogus, as: Gateway
 
+  @some_id "some_arbitrary_id"
+  @amount Money.new(5, :USD)
+  
   test "authorize" do
     {:ok, %Response{id: id, success: success}} =
-        Gateway.authorize(10.95, :card, [])
+        Gateway.authorize(@amount, :card, [])
 
     assert success
     assert id != nil
@@ -14,7 +17,7 @@ defmodule Gringotts.Gateways.BogusTest do
 
   test "purchase" do
     {:ok, %Response{id: id, success: success}} =
-        Gateway.purchase(10.95, :card, [])
+        Gateway.purchase(@amount, :card, [])
 
     assert success
     assert id != nil
@@ -22,7 +25,7 @@ defmodule Gringotts.Gateways.BogusTest do
 
   test "capture" do
     {:ok, %Response{id: id, success: success}} =
-        Gateway.capture(1234, 5, [])
+        Gateway.capture(@some_id, @amount, [])
 
     assert success
     assert id != nil
@@ -30,7 +33,7 @@ defmodule Gringotts.Gateways.BogusTest do
 
   test "void" do
     {:ok, %Response{id: id, success: success}} =
-        Gateway.void(1234, [])
+        Gateway.void(@some_id, [])
 
     assert success
     assert id != nil
@@ -45,7 +48,7 @@ defmodule Gringotts.Gateways.BogusTest do
 
   test "unstore with customer" do
     {:ok, %Response{success: success}} =
-        Gateway.unstore(1234, [])
+        Gateway.unstore(@some_id, [])
 
     assert success
   end


### PR DESCRIPTION
* Improved `Adapter` `moduledoc` and bogus gateway
  - Fixes #24 (bogus gateway)
  - `bogus_test` also uses `Money` protocol now
* `validate_config` docs explain its operation.
* mix task: `gringotts.new`
  - Improved docs
  - Better module name suggestion
  - Filename can be specified on the CLI with the `-f` flag
* Added changelog and contributing guide.
* Correct "amount" in examples to ex_money 