### PR TITLE
[CAMS] Adapt for new Response.t

### DIFF
--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -443,26 +443,10 @@ defmodule Gringotts.Gateways.Cams do
       end
     end
 
-    def parse({:ok, %HTTPoison.Response{body: body, status_code: 400}}) do
+    def parse({:ok, %HTTPoison.Response{body: body, status_code: code}}) do
       response = %Response{
-        status_code: 400,
+        status_code: code,
         raw: body
-      }
-
-      {:error, response}
-    end
-
-    # There is no mock test for this.
-    # Don't know in which scenario we recieve a 404 :(
-    def parse({:ok, %HTTPoison.Response{body: body, status_code: 404}}) do
-      decoded_body = URI.decode_query(body)
-      error_message = List.to_string(Map.keys(decoded_body))
-      [_ | parse_message] = Regex.run(~r|<title>(.*)</title>|, error_message)
-      message = List.to_string(parse_message)
-      response = %Response{
-        status_code: 404,
-        raw: body,
-        reason: message
       }
 
       {:error, response}

--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -144,7 +144,7 @@ defmodule Gringotts.Gateways.Cams do
   ## Optional Fields
       options[
         order_id: String,
-        description: String     
+        description: String
       ]
 
   ## Examples
@@ -163,7 +163,7 @@ defmodule Gringotts.Gateways.Cams do
   iex> {:ok, auth_result} = Gringotts.authorize(Gringotts.Gateways.Cams, money, card)
   ```
   """
-  @spec authorize(Money.t(), CreditCard.t(), keyword) :: {:ok | :error, Response}
+  @spec authorize(Money.t(), CreditCard.t(), keyword) :: {:ok | :error, Response.t()}
   def authorize(money, %CreditCard{} = card, options) do
     params =
       []
@@ -210,7 +210,7 @@ defmodule Gringotts.Gateways.Cams do
   iex> {:ok, capture_result} = Gringotts.capture(Gringotts.Gateways.Cams, money, authorization)
   ```
   """
-  @spec capture(Money.t(), String.t(), keyword) :: {:ok | :error, Response}
+  @spec capture(Money.t(), String.t(), keyword) :: {:ok | :error, Response.t()}
   def capture(money, transaction_id, options) do
     params =
       [transactionid: transaction_id]
@@ -246,7 +246,7 @@ defmodule Gringotts.Gateways.Cams do
   iex> Gringotts.purchase(Gringotts.Gateways.Cams, money, card)
   ```
   """
-  @spec purchase(Money.t(), CreditCard.t(), keyword) :: {:ok | :error, Response}
+  @spec purchase(Money.t(), CreditCard.t(), keyword) :: {:ok | :error, Response.t()}
   def purchase(money, %CreditCard{} = card, options) do
     params =
       []
@@ -278,7 +278,7 @@ defmodule Gringotts.Gateways.Cams do
   iex> Gringotts.refund(Gringotts.Gateways.Cams, money, capture_id)
   ```
   """
-  @spec refund(Money.t(), String.t(), keyword) :: {:ok | :error, Response}
+  @spec refund(Money.t(), String.t(), keyword) :: {:ok | :error, Response.t()}
   def refund(money, transaction_id, options) do
     params =
       [transactionid: transaction_id]
@@ -305,7 +305,7 @@ defmodule Gringotts.Gateways.Cams do
   iex> Gringotts.void(Gringotts.Gateways.Cams, auth_id)
   ```
   """
-  @spec void(String.t(), keyword) :: {:ok | :error, Response}
+  @spec void(String.t(), keyword) :: {:ok | :error, Response.t()}
   def void(transaction_id, options) do
     params = [transactionid: transaction_id]
     commit("void", params, options)
@@ -328,7 +328,7 @@ defmodule Gringotts.Gateways.Cams do
   iex> Gringotts.validate(Gringotts.Gateways.Cams, card)
   ```
   """
-  @spec validate(CreditCard.t(), keyword) :: {:ok | :error, Response}
+  @spec validate(CreditCard.t(), keyword) :: {:ok | :error, Response.t()}
   def validate(card, options) do
     params =
       []
@@ -378,76 +378,105 @@ defmodule Gringotts.Gateways.Cams do
     @moduledoc false
     alias Gringotts.Response
 
+    # Fetched from CAMS POST API docs.
+    @avs_code_translator %{
+      "X" => {nil, "pass: 9-character numeric ZIP"},
+      "Y" => {nil, "pass: 5-character numeric ZIP"},
+      "D" => {nil, "pass: 5-character numeric ZIP"},
+      "M" => {nil, "pass: 5-character numeric ZIP"},
+      "2" => {"pass: customer name", "pass: 5-character numeric ZIP"},
+      "6" => {"pass: customer name", "pass: 5-character numeric ZIP"},
+      "A" => {"pass: only address", "fail"},
+      "B" => {"pass: only address", "fail"},
+      "3" => {"pass: address, customer name", "fail"},
+      "7" => {"pass: address, customer name", "fail"},
+      "W" => {"fail", "pass: 9-character numeric ZIP match"},
+      "Z" => {"fail", "pass: 5-character ZIP match"},
+      "P" => {"fail", "pass: 5-character ZIP match"},
+      "L" => {"fail", "pass: 5-character ZIP match"},
+      "1" => {"pass: only customer name", "pass: 5-character ZIP"},
+      "5" => {"pass: only customer name", "pass: 5-character ZIP"},
+      "N" => {"fail", "fail"},
+      "C" => {"fail", "fail"},
+      "4" => {"fail", "fail"},
+      "8" => {"fail", "fail"},
+      "U" => {nil, nil},
+      "G" => {nil, nil},
+      "I" => {nil, nil},
+      "R" => {nil, nil},
+      "E" => {nil, nil},
+      "S" => {nil, nil},
+      "0" => {nil, nil},
+      "O" => {nil, nil},
+      ""  => {nil, nil}
+    }
+
+    # Fetched from CAMS POST API docs.
+    @cvc_code_translator %{
+      "M" => "pass",
+      "N" => "fail",
+      "P" => "not_processed",
+      "S" => "Merchant indicated that CVV2/CVC2 is not present on card",
+      "U" => "Issuer is not certified and/or has not provided Visa encryption key"
+    }
+
     @doc false
     def parse({:ok, %HTTPoison.Response{body: body, status_code: 200}}) do
-      body = URI.decode_query(body)
+      decoded_body = URI.decode_query(body)
+      {street, zip_code} = @avs_code_translator[decoded_body["avsresponse"]]
+      gateway_code = decoded_body["response_code"]
 
-      [status_code: 200]
-      |> set_authorization(body)
-      |> set_success(body)
-      |> set_message(body)
-      |> set_params(body)
-      |> set_error_code(body)
-      |> handle_opts()
+      response = %Response{
+        status_code: 200,
+        id: decoded_body["transactionid"],
+        gateway_code: gateway_code,
+        avs_result: %{street: street, zip_code: zip_code},
+        cvc_result: @cvc_code_translator[decoded_body["cvvresponse"]],
+        message: decoded_body["responsetext"],
+        raw: body
+      }
+
+      {successful?(gateway_code), response}
     end
 
     def parse({:ok, %HTTPoison.Response{body: body, status_code: 400}}) do
-      body = URI.decode_query(body)
-      set_params([status_code: 400], body)
+      response = %Response{
+        status_code: 400,
+        raw: body
+      }
+
+      {:error, response}
     end
 
+    # There is no mock test for this.
+    # Don't know in which scenario we recieve a 404 :(
     def parse({:ok, %HTTPoison.Response{body: body, status_code: 404}}) do
-      body = URI.decode_query(body)
+      decoded_body = URI.decode_query(body)
+      error_message = List.to_string(Map.keys(decoded_body))
+      [_ | parse_message] = Regex.run(~r|<title>(.*)</title>|, error_message)
+      message = List.to_string(parse_message)
+      response = %Response{
+        status_code: 404,
+        raw: body,
+        message: message
+      }
 
-      [status_code: 404]
-      |> handle_not_found(body)
-      |> handle_opts()
+      {:error, response}
     end
 
     def parse({:error, %HTTPoison.Error{} = error}) do
-      [
-        message: "HTTPoison says #{error.reason}",
-        error_code: error.id,
-        success: false
-      ]
+      {
+        :error,
+        %Response{
+          reason: "network related failure",
+          message: "HTTPoison says '#{error.reason}' [ID: #{error.id || "nil"}]",
+          success: false
+        }
+      }
     end
 
-    defp set_authorization(opts, %{"transactionid" => id}) do
-      opts ++ [authorization: id]
-    end
-
-    defp set_message(opts, %{"responsetext" => message}) do
-      opts ++ [message: message]
-    end
-
-    defp set_params(opts, body) do
-      opts ++ [params: body]
-    end
-
-    defp set_error_code(opts, %{"response_code" => response_code}) do
-      opts ++ [error_code: response_code]
-    end
-
-    defp set_success(opts, %{"response_code" => response_code}) do
-      opts ++ [success: response_code == "100"]
-    end
-
-    defp handle_not_found(opts, body) do
-      error = parse_html(body)
-      opts ++ [success: false, message: error]
-    end
-
-    defp parse_html(body) do
-      error_message = List.to_string(Map.keys(body))
-      [_ | parse_message] = Regex.run(~r|<title>(.*)</title>|, error_message)
-      List.to_string(parse_message)
-    end
-
-    defp handle_opts(opts) do
-      case Keyword.fetch(opts, :success) do
-        {:ok, true} -> {:ok, Response.success(opts)}
-        {:ok, false} -> {:ok, Response.error(opts)}
-      end
+    defp successful?(gateway_code) do
+      if gateway_code == "100", do: :ok, else: :error
     end
   end
 end


### PR DESCRIPTION
* Refactored `ResponseHandler`
  * Removed unnecessary one-liners which avoids unnecessary appends.
  * Used better variable and function names.
  * CAMS now parses AVS and CVV response - that was missing till now.
  * **CAMS always returned an `:ok` tuple!** Fixed that. (Look at the old tests)
* Added `reason` to `Resonse.t` in cases of error. 
* Removes unnecessary `parse` clause. 