### PR TITLE
[ANet] Adapt for new `Response.t`

### DIFF
--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -102,7 +102,6 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   """
 
   import XmlBuilder
-  import XmlToMap
 
   use Gringotts.Gateways.Base
   use Gringotts.Adapter, required_config: [:name, :transaction_key]
@@ -398,9 +397,9 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   def store(card, opts) do
     request_data =
       if opts[:customer_profile_id] do
-        card |> create_customer_payment_profile(opts) |> generate
+        card |> create_customer_payment_profile(opts) |> generate(format: :none)
       else
-        card |> create_customer_profile(opts) |> generate
+        card |> create_customer_profile(opts) |> generate(format: :none)
       end
 
     response_data = commit(:post, request_data, opts)
@@ -421,42 +420,32 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
   @spec unstore(String.t(), Keyword.t()) :: {:ok | :error, Response}
   def unstore(customer_profile_id, opts) do
-    request_data = customer_profile_id |> delete_customer_profile(opts) |> generate
+    request_data = customer_profile_id |> delete_customer_profile(opts) |> generate(format: :none)
     response_data = commit(:post, request_data, opts)
     respond(response_data)
   end
 
-  # method to make the api request with params
+  # method to make the API request with params
   defp commit(method, payload, opts) do
     path = base_url(opts)
     headers = @header
     HTTPoison.request(method, path, payload, headers)
   end
 
-  # Function to return a response
-  defp respond({:ok, %{body: body, status_code: 200}}) do
-    raw_response = naive_map(body)
-    response_type = ResponseHandler.check_response_type(raw_response)
-    response_check(raw_response[response_type], raw_response)
-  end
+  defp respond({:ok, %{body: body, status_code: 200}}), do: ResponseHandler.respond(body)
 
   defp respond({:ok, %{body: body, status_code: code}}) do
-    {:error, Response.error(params: body, error_code: code)}
+    {:error, %Response{raw: body, status_code: code}}
   end
 
   defp respond({:error, %HTTPoison.Error{} = error}) do
-    {:error, Response.error(error_code: error.id, message: "HTTPoison says '#{error.reason}'")}
-  end
-
-  # Functions to send successful and error responses depending on message received
-  # from gateway.
-
-  defp response_check(%{"messages" => %{"resultCode" => "Ok"}}, raw_response) do
-    {:ok, ResponseHandler.parse_gateway_success(raw_response)}
-  end
-
-  defp response_check(%{"messages" => %{"resultCode" => "Error"}}, raw_response) do
-    {:error, ResponseHandler.parse_gateway_error(raw_response)}
+    {
+      :error,
+      %Response{
+        reason: "network related failure",
+        message: "HTTPoison says '#{error.reason}' [ID: #{error.id || "nil"}]"
+      }
+    }
   end
 
   ##############################################################################
@@ -471,7 +460,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       add_order_id(opts),
       add_purchase_transaction_request(amount, transaction_type, payment, opts)
     ])
-    |> generate
+    |> generate(format: :none)
   end
 
   # function for formatting the request for  normal capture
@@ -482,7 +471,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       add_order_id(opts),
       add_capture_transaction_request(amount, id, transaction_type, opts)
     ])
-    |> generate
+    |> generate(format: :none)
   end
 
   # function to format the request for normal refund
@@ -493,7 +482,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       add_order_id(opts),
       add_refund_transaction_request(amount, id, opts, transaction_type)
     ])
-    |> generate
+    |> generate(format: :none)
   end
 
   # function to format the request for normal void operation
@@ -507,7 +496,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
         add_ref_trans_id(id)
       ])
     ])
-    |> generate
+    |> generate(format: :none)
   end
 
   defp create_customer_payment_profile(card, opts) do
@@ -747,88 +736,98 @@ defmodule Gringotts.Gateways.AuthorizeNet do
     end
   end
 
+  ##################################################################################
+  #                               RESPONSE_HANDLER MODULE                          #
+  #                                                                                #
+  ##################################################################################
+
   defmodule ResponseHandler do
     @moduledoc false
     alias Gringotts.Response
 
-    @response_type %{
-      auth_response: "authenticateTestResponse",
-      transaction_response: "createTransactionResponse",
-      error_response: "ErrorResponse",
-      customer_profile_response: "createCustomerProfileResponse",
-      customer_payment_profile_response: "createCustomerPaymentProfileResponse",
-      delete_customer_profile: "deleteCustomerProfileResponse"
-    }
+    @supported_response_types [
+      "authenticateTestResponse",
+      "createTransactionResponse",
+      "ErrorResponse",
+      "createCustomerProfileResponse",
+      "createCustomerPaymentProfileResponse",
+      "deleteCustomerProfileResponse"
+    ]
 
-    def parse_gateway_success(raw_response) do
-      response_type = check_response_type(raw_response)
-      token = raw_response[response_type]["transactionResponse"]["transId"]
-      message = raw_response[response_type]["messages"]["message"]["text"]
-      avs_result = raw_response[response_type]["transactionResponse"]["avsResultCode"]
-      cvc_result = raw_response[response_type]["transactionResponse"]["cavvResultCode"]
+    def respond(body) do
+      response_map = XmlToMap.naive_map(body)
+      case extract_gateway_response(response_map) do
+        :undefined_response ->
+          {
+            :error,
+            %Response{
+              reason: "Undefined response from AunthorizeNet",
+              raw: body,
+              message: "You might wish to open an issue with Gringotts."
+            }
+          }
 
-      []
-      |> status_code(200)
-      |> set_token(token)
+        result ->
+          build_response(result, %Response{raw: body, status_code: 200})
+      end
+    end
+
+    def extract_gateway_response(response_map) do
+      # The type of the response should be supported
+      @supported_response_types
+      |> Stream.map(&Map.get(response_map, &1, nil))
+      # Find the first non-nil from the above, if all are `nil`...
+      # We are in trouble!
+      |> Enum.find(:undefined_response, &(&1))
+    end
+
+    defp build_response(%{"messages" => %{"resultCode" => "Ok"}} = result, base_response) do
+      {:ok, ResponseHandler.parse_gateway_success(result, base_response)}
+    end
+
+    defp build_response(%{"messages" => %{"resultCode" => "Error"}} = result, base_response) do
+      {:error, ResponseHandler.parse_gateway_error(result, base_response)}
+    end
+
+    def parse_gateway_success(result, base_response) do
+      id = result["transactionResponse"]["transId"]
+      message = result["messages"]["message"]["text"]
+      avs_result = result["transactionResponse"]["avsResultCode"]
+      cvc_result = result["transactionResponse"]["cavvResultCode"]
+      gateway_code = result["messages"]["message"]["code"]
+
+      base_response
+      |> set_id(id)
       |> set_message(message)
+      |> set_gateway_code(gateway_code)
       |> set_avs_result(avs_result)
       |> set_cvc_result(cvc_result)
-      |> set_params(raw_response)
-      |> set_success(true)
-      |> handle_opts
     end
 
-    def parse_gateway_error(raw_response) do
-      response_type = check_response_type(raw_response)
+    def parse_gateway_error(result, base_response) do
+      message = result["messages"]["message"]["text"]
+      gateway_code = result["messages"]["message"]["code"]
 
-      {message, error_code} =
-        if raw_response[response_type]["transactionResponse"]["errors"] do
-          {
-            raw_response[response_type]["messages"]["message"]["text"] <>
-              " " <>
-              raw_response[response_type]["transactionResponse"]["errors"]["error"]["errorText"],
-            raw_response[response_type]["transactionResponse"]["errors"]["error"]["errorCode"]
-          }
-        else
-          {
-            raw_response[response_type]["messages"]["message"]["text"],
-            raw_response[response_type]["messages"]["message"]["code"]
-          }
-        end
+      error_text = result["transactionResponse"]["errors"]["error"]["errorText"]
+      error_code = result["transactionResponse"]["errors"]["error"]["errorCode"]
+      reason = "#{error_text} [Error code (#{error_code})]"
 
-      []
-      |> status_code(200)
+      base_response
       |> set_message(message)
-      |> set_error_code(error_code)
-      |> set_params(raw_response)
-      |> set_success(false)
-      |> handle_opts
+      |> set_gateway_code(gateway_code)
+      |> set_reason(reason)
     end
 
-    def check_response_type(raw_response) do
-      cond do
-        raw_response[@response_type[:transaction_response]] -> "createTransactionResponse"
-        raw_response[@response_type[:error_response]] -> "ErrorResponse"
-        raw_response[@response_type[:customer_profile_response]] -> "createCustomerProfileResponse"
-        raw_response[@response_type[:customer_payment_profile_response]] -> "createCustomerPaymentProfileResponse"
-        raw_response[@response_type[:delete_customer_profile]] -> "deleteCustomerProfileResponse"
-      end
-    end
+    ############################################################################
+    #                                   HELPERS                                #
+    ############################################################################
 
-    defp set_token(opts, token), do: [{:authorization, token} | opts]
-    defp set_success(opts, value), do: [{:success, value} | opts]
-    defp status_code(opts, code), do: [{:status, code} | opts]
-    defp set_message(opts, message), do: [{:message, message} | opts]
-    defp set_avs_result(opts, result), do: [{:avs, result} | opts]
-    defp set_cvc_result(opts, result), do: [{:cvc, result} | opts]
-    defp set_params(opts, raw_response), do: [{:params, raw_response} | opts]
-    defp set_error_code(opts, code), do: [{:error, code} | opts]
+    defp set_id(response, id),             do: %{response | id: id}
+    defp set_message(response, message),   do: %{response | message: message}
+    defp set_gateway_code(response, code), do: %{response | gateway_code: code}
+    defp set_reason(response, body),       do: %{response | reason: body}
 
-    defp handle_opts(opts) do
-      case Keyword.fetch(opts, :success) do
-        {:ok, true} -> Response.success(opts)
-        {:ok, false} -> Response.error(opts)
-      end
-    end
+    defp set_avs_result(response, result), do: %{response | avs_result: result}
+    defp set_cvc_result(response, result), do: %{response | cvc_result: result}
   end
 end

--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -95,7 +95,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
   ```
   iex> alias Gringotts.{Response, CreditCard, Gateways.AuthorizeNet}
-  iex> amount = %{value: Decimal.new(20.0), currency: "USD"}
+  iex> amount = Money.new(20, :USD}
   iex> card = %CreditCard{number: "5424000000000015", year: 2099, month: 12, verification_code: "999"}
   ```
 
@@ -137,8 +137,8 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   Charges a credit `card` for the specified `amount`. It performs `authorize`
   and `capture` at the [same time][auth-cap-same-time].
 
-  Authorize.Net returns `transId` (available in the `Response.authorization`
-  field) which can be used to:
+  Authorize.Net returns `transId` (available in the `Response.id` field) which
+  can be used to:
 
   * `refund/3` a settled transaction.
   * `void/2` a transaction.
@@ -171,7 +171,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       ]
 
   ## Example
-      iex> amount = %{value: Decimal.new(20.0), currency: "USD"}
+      iex> amount = Money.new(20, :USD}
       iex> opts = [
         ref_id: "123456",
         order: %{invoice_number: "INV-12345", description: "Product Description"},
@@ -183,7 +183,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> card = %CreditCard{number: "5424000000000015", year: 2099, month: 12, verification_code: "999"}
       iex> result = Gringotts.purchase(Gringotts.Gateways.AuthorizeNet, amount, card, opts)
   """
-  @spec purchase(Money.t(), CreditCard.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec purchase(Money.t(), CreditCard.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def purchase(amount, payment, opts) do
     request_data = add_auth_purchase(amount, payment, opts, @transaction_type[:purchase])
     commit(request_data, opts)
@@ -198,8 +198,8 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
   To transfer the funds to merchant's account follow this up with a `capture/3`.
 
-  Authorize.Net returns a `transId` (available in the `Response.authorization`
-  field) which can be used for:
+  Authorize.Net returns a `transId` (available in the `Response.id` field) which
+  can be used for:
 
   * `capture/3` an authorized transaction.
   * `void/2` a transaction.
@@ -231,7 +231,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
 
   ## Example
-      iex> amount = %{value: Decimal.new(20.0), currency: "USD"}
+      iex> amount = Money.new(20, :USD}
       iex> opts = [
         ref_id: "123456",
         order: %{invoice_number: "INV-12345", description: "Product Description"},
@@ -243,7 +243,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> card = %CreditCard{number: "5424000000000015", year: 2099, month: 12, verification_code: "999"}
       iex> result = Gringotts.authorize(Gringotts.Gateways.AuthorizeNet, amount, card, opts)
   """
-  @spec authorize(Money.t(), CreditCard.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec authorize(Money.t(), CreditCard.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def authorize(amount, payment, opts) do
     request_data = add_auth_purchase(amount, payment, opts, @transaction_type[:authorize])
     commit(request_data, opts)
@@ -255,8 +255,8 @@ defmodule Gringotts.Gateways.AuthorizeNet do
   `amount` is transferred to the merchant account by Authorize.Net when it is smaller or
   equal to the amount used in the pre-authorization referenced by `id`.
 
-  Authorize.Net returns a `transId` (available in the `Response.authorization`
-  field) which can be used to:
+  Authorize.Net returns a `transId` (available in the `Response.id` field) which
+  can be used to:
 
   * `refund/3` a settled transaction.
   * `void/2` a transaction.
@@ -281,11 +281,11 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> opts = [
         ref_id: "123456"
       ]
-      iex> amount = %{value: Decimal.new(20.0), currency: "USD"}
+      iex> amount = Money.new(20, :USD}
       iex> id = "123456"
       iex> result = Gringotts.capture(Gringotts.Gateways.AuthorizeNet, id, amount, opts)
   """
-  @spec capture(String.t(), Money.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec capture(String.t(), Money.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def capture(id, amount, opts) do
     request_data = normal_capture(amount, id, opts, @transaction_type[:capture])
     commit(request_data, opts)
@@ -311,10 +311,10 @@ defmodule Gringotts.Gateways.AuthorizeNet do
         ref_id: "123456"
       ]
       iex> id = "123456"
-      iex> amount = %{value: Decimal.new(20.0), currency: "USD"}
+      iex> amount = Money.new(20, :USD}
       iex> result = Gringotts.refund(Gringotts.Gateways.AuthorizeNet, amount, id, opts)
   """
-  @spec refund(Money.t(), String.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec refund(Money.t(), String.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def refund(amount, id, opts) do
     request_data = normal_refund(amount, id, opts, @transaction_type[:refund])
     commit(request_data, opts)
@@ -339,7 +339,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> id = "123456"
       iex> result = Gringotts.void(Gringotts.Gateways.AuthorizeNet, id, opts)
   """
-  @spec void(String.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec void(String.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def void(id, opts) do
     request_data = normal_void(id, opts, @transaction_type[:void])
     commit(request_data, opts)
@@ -392,7 +392,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> card = %CreditCard{number: "5424000000000015", year: 2099, month: 12, verification_code: "999"}
       iex> result = Gringotts.store(Gringotts.Gateways.AuthorizeNet, card, opts)
   """
-  @spec store(CreditCard.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec store(CreditCard.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def store(card, opts) do
     request_data =
       if opts[:customer_profile_id] do
@@ -412,11 +412,10 @@ defmodule Gringotts.Gateways.AuthorizeNet do
 
   ## Example
       iex> id = "123456"
-      iex> opts = []
-      iex> result = Gringotts.store(Gringotts.Gateways.AuthorizeNet, id, opts)
+      iex> result = Gringotts.store(Gringotts.Gateways.AuthorizeNet, id)
   """
 
-  @spec unstore(String.t(), Keyword.t()) :: {:ok | :error, Response}
+  @spec unstore(String.t(), Keyword.t()) :: {:ok | :error, Response.t()}
   def unstore(customer_profile_id, opts) do
     request_data = customer_profile_id |> delete_customer_profile(opts) |> generate(format: :none)
     commit(request_data, opts)

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Gringotts.Mixfile do
     [
       {:poison, "~> 3.1.0"},
       {:httpoison, "~> 0.13"},
-      {:xml_builder, "~> 0.1.1"},
+      {:xml_builder, "~> 2.1"},
       {:elixir_xml_to_map, "~> 0.1"},
 
       # Money related

--- a/mix.lock
+++ b/mix.lock
@@ -35,4 +35,4 @@
   "timex": {:hex, :timex, "3.1.25", "6002dae5432f749d1c93e2cd103eb73cecb53e50d2c885349e8e4146fc96bd44", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "xml_builder": {:hex, :xml_builder, "0.1.2", "b48ab9ed0a24f43a6061e0c21deda88b966a2121af5c445d4fc550dd822e23dc", [:mix], [], "hexpm"}}
+  "xml_builder": {:hex, :xml_builder, "2.1.0", "c249d5339427c13cae11e9d9d0e8b40d25d228b9ecc54029f24017385e60280b", [:mix], [], "hexpm"}}

--- a/test/gateways/authorize_net_test.exs
+++ b/test/gateways/authorize_net_test.exs
@@ -121,7 +121,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "purchase" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.successful_purchase_response()
         end do
         assert {:ok, response} = ANet.purchase(@amount, @card, @opts)
@@ -130,7 +130,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
     test "with bad card" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.bad_card_purchase_response()
         end do
         assert {:error, response} = ANet.purchase(@amount, @bad_card, @opts)
@@ -141,7 +141,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "authorize" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.successful_authorize_response()
         end do
         assert {:ok, response} = ANet.authorize(@amount, @card, @opts)
@@ -150,7 +150,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
     test "with bad card" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.bad_card_purchase_response()
         end do
         assert {:error, response} = ANet.authorize(@amount, @bad_card, @opts)
@@ -161,7 +161,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "capture" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.successful_capture_response()
         end do
         assert {:ok, response} = ANet.capture(@capture_id, @amount, @opts)
@@ -170,7 +170,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
     test "with bad transaction id" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.bad_id_capture() end do
+        post: fn _url, _body, _headers -> MockResponse.bad_id_capture() end do
         assert {:error, response} = ANet.capture(@capture_invalid_id, @amount, @opts)
       end
     end
@@ -179,7 +179,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "refund" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.successful_refund_response()
         end do
         assert {:ok, response} = ANet.refund(@amount, @refund_id, @opts_refund)
@@ -188,14 +188,14 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
     test "bad payment params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.bad_card_refund() end do
+        post: fn _url, _body, _headers -> MockResponse.bad_card_refund() end do
         assert {:error, response} = ANet.refund(@amount, @refund_id, @opts_refund_bad_payment)
       end
     end
 
     test "debit less than refund amount" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.debit_less_than_refund() end do
+        post: fn _url, _body, _headers -> MockResponse.debit_less_than_refund() end do
         assert {:error, response} = ANet.refund(@amount, @refund_id, @opts_refund)
       end
     end
@@ -204,14 +204,14 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "void" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.successful_void() end do
+        post: fn _url, _body, _headers -> MockResponse.successful_void() end do
         assert {:ok, response} = ANet.void(@void_id, @opts)
       end
     end
 
     test "with bad transaction id" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.void_non_existent_id() end do
+        post: fn _url, _body, _headers -> MockResponse.void_non_existent_id() end do
         assert {:error, response} = ANet.void(@void_invalid_id, @opts)
       end
     end
@@ -220,21 +220,21 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "store" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.successful_store_response() end do
+        post: fn _url, _body, _headers -> MockResponse.successful_store_response() end do
         assert {:ok, response} = ANet.store(@card, @opts_store)
       end
     end
 
     test "successful response without validation and customer type" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.successful_store_response() end do
+        post: fn _url, _body, _headers -> MockResponse.successful_store_response() end do
         assert {:ok, response} = ANet.store(@card, @opts_store_without_validation)
       end
     end
 
     test "without any profile" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.store_without_profile_fields()
         end do
         assert {:error, response} = ANet.store(@card, @opts_store_no_profile)
@@ -245,7 +245,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
     test "with customer profile id" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.customer_payment_profile_success_response()
         end do
         assert {:ok, response} = ANet.store(@card, @opts_customer_profile)
@@ -256,7 +256,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
     test "successful response without valiadtion mode and customer type" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers -> MockResponse.successful_store_response() end do
+        post: fn _url, _body, _headers -> MockResponse.successful_store_response() end do
         assert {:ok, response} = ANet.store(@card, @opts_customer_profile_args)
       end
     end
@@ -265,7 +265,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
   describe "unstore" do
     test "successful response with right params" do
       with_mock HTTPoison,
-        request: fn _method, _url, _body, _headers ->
+        post: fn _url, _body, _headers ->
           MockResponse.successful_unstore_response()
         end do
         assert {:ok, response} = ANet.unstore(@unstore_id, @opts)
@@ -275,7 +275,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
 
   test "network error type non existent domain" do
     with_mock HTTPoison,
-      request: fn _method, _url, _body, _headers ->
+      post: fn _url, _body, _headers ->
         MockResponse.netwok_error_non_existent_domain()
       end do
       assert {:error, response} = ANet.purchase(@amount, @card, @opts)

--- a/test/gateways/authorize_net_test.exs
+++ b/test/gateways/authorize_net_test.exs
@@ -125,7 +125,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.successful_purchase_response()
         end do
         assert {:ok, response} = ANet.purchase(@amount, @card, @opts)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -135,7 +134,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.bad_card_purchase_response()
         end do
         assert {:error, response} = ANet.purchase(@amount, @bad_card, @opts)
-        assert response.params["ErrorResponse"]["messages"]["resultCode"] == "Error"
       end
     end
   end
@@ -147,7 +145,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.successful_authorize_response()
         end do
         assert {:ok, response} = ANet.authorize(@amount, @card, @opts)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -157,7 +154,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.bad_card_purchase_response()
         end do
         assert {:error, response} = ANet.authorize(@amount, @bad_card, @opts)
-        assert response.params["ErrorResponse"]["messages"]["resultCode"] == "Error"
       end
     end
   end
@@ -169,7 +165,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.successful_capture_response()
         end do
         assert {:ok, response} = ANet.capture(@capture_id, @amount, @opts)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -177,7 +172,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.bad_id_capture() end do
         assert {:error, response} = ANet.capture(@capture_invalid_id, @amount, @opts)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Error"
       end
     end
   end
@@ -189,7 +183,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.successful_refund_response()
         end do
         assert {:ok, response} = ANet.refund(@amount, @refund_id, @opts_refund)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -197,7 +190,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.bad_card_refund() end do
         assert {:error, response} = ANet.refund(@amount, @refund_id, @opts_refund_bad_payment)
-        assert response.params["ErrorResponse"]["messages"]["resultCode"] == "Error"
       end
     end
 
@@ -205,7 +197,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.debit_less_than_refund() end do
         assert {:error, response} = ANet.refund(@amount, @refund_id, @opts_refund)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Error"
       end
     end
   end
@@ -215,7 +206,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.successful_void() end do
         assert {:ok, response} = ANet.void(@void_id, @opts)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -223,7 +213,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.void_non_existent_id() end do
         assert {:error, response} = ANet.void(@void_invalid_id, @opts)
-        assert response.params["createTransactionResponse"]["messages"]["resultCode"] == "Error"
       end
     end
   end
@@ -233,7 +222,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.successful_store_response() end do
         assert {:ok, response} = ANet.store(@card, @opts_store)
-        assert response.params["createCustomerProfileResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -241,7 +229,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.successful_store_response() end do
         assert {:ok, response} = ANet.store(@card, @opts_store_without_validation)
-        assert response.params["createCustomerProfileResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
 
@@ -252,7 +239,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
         end do
         assert {:error, response} = ANet.store(@card, @opts_store_no_profile)
 
-        assert response.params["createCustomerProfileResponse"]["messages"]["resultCode"] ==
                  "Error"
       end
     end
@@ -264,7 +250,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
         end do
         assert {:ok, response} = ANet.store(@card, @opts_customer_profile)
 
-        assert response.params["createCustomerPaymentProfileResponse"]["messages"]["resultCode"] ==
                  "Ok"
       end
     end
@@ -273,7 +258,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
       with_mock HTTPoison,
         request: fn _method, _url, _body, _headers -> MockResponse.successful_store_response() end do
         assert {:ok, response} = ANet.store(@card, @opts_customer_profile_args)
-        assert response.params["createCustomerProfileResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
   end
@@ -285,7 +269,6 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
           MockResponse.successful_unstore_response()
         end do
         assert {:ok, response} = ANet.unstore(@unstore_id, @opts)
-        assert response.params["deleteCustomerProfileResponse"]["messages"]["resultCode"] == "Ok"
       end
     end
   end
@@ -296,7 +279,7 @@ defmodule Gringotts.Gateways.AuthorizeNetTest do
         MockResponse.netwok_error_non_existent_domain()
       end do
       assert {:error, response} = ANet.purchase(@amount, @card, @opts)
-      assert response.message == "HTTPoison says 'nxdomain'"
+      assert response.message == "HTTPoison says 'nxdomain' [ID: nil]"
     end
   end
 end


### PR DESCRIPTION
- Updated dependency `xml_builder`. The new `generate/2` provides a `format: :none | :indented` option.
- `:format` is set to `:none` to produce "minified" network requests.

## Refactored `ResponseHandler`, for new `Response.t`
* This is almost a complete rewrite to reduce code duplication.
  - `check_response_type/1` was acting as guard that matched only against some response types. It did not handle the scenario when a non-supported response would be obtained. It really served no purpose.
  - `check_response_type` -> `extract_gateway_response`
    + This guards as well as fetches, previously the fetch was being done multiple times.
* Moved all response handling inside the `ResponseHandler`.
* Since we now have a struct, and want to deprecate `:success`, `Response.success/1` and  `Response.error/1`, helpers now act on structs.
* `errorCode` and `errorText` are used to build `:reason`.

+ Removed pointless asserts from tests.


## Refactored `commit` and corrected avs, cvc result

Also added CAVV result filed to the response which is nil for MasterCards (as per ANet docs).