### PR TITLE
Fix option name in authorize/3 example

### DIFF
--- a/lib/gringotts/gateways/authorize_net.ex
+++ b/lib/gringotts/gateways/authorize_net.ex
@@ -229,7 +229,7 @@ defmodule Gringotts.Gateways.AuthorizeNet do
       iex> opts = [
         ref_id: "123456",
         order: %{invoice_number: "INV-12345", description: "Product Description"},
-        lineitems: %{itemId: "1", name: "vase", description: "Cannes logo", quantity: 1, unit_price: amount},
+        lineitems: %{item_id: "1", name: "vase", description: "Cannes logo", quantity: 1, unit_price: amount},
         tax: %{name: "VAT", amount: Money.new("0.1", :EUR), description: "Value Added Tax"},
         shipping: %{name: "SAME-DAY-DELIVERY", amount: Money.new("0.56", :EUR), description: "Zen Logistics"},
         duty: %{name: "import_duty", amount: Money.new("0.25", :EUR), description: "Upon import of goods"}


### PR DESCRIPTION
The access key used to grab the item id from an item is `:item_id` [here](https://github.com/aviabird/gringotts/blob/dev/lib/gringotts/gateways/authorize_net.ex#L632), but the example on line 232 uses `:itemId`