### PR TITLE
Small refactoring to fix credo linting warnings

### DIFF
--- a/lib/mix/new.ex
+++ b/lib/mix/new.ex
@@ -99,7 +99,7 @@ Comma separated list of required configuration keys:
           []
 
         keys ->
-          String.split(keys, ",") |> Enum.map(&String.trim(&1)) |> Enum.map(&String.to_atom(&1))
+          keys_to_atom(keys, ",")
       end
 
     bindings = [
@@ -138,5 +138,12 @@ Comma separated list of required configuration keys:
     decorated_message = "#{message} [#{suggestion}]"
     response = Mix.Shell.IO.prompt(decorated_message) |> String.trim()
     if response == "", do: suggestion, else: response
+  end
+
+  defp keys_to_atom(key_list, splitter) when is_binary(key_list) do
+    key_list
+    |> String.split(splitter)
+    |> Enum.map(&String.trim/1)
+    |> Enum.map(&String.to_atom/1)
   end
 end

--- a/lib/mix/new.ex
+++ b/lib/mix/new.ex
@@ -94,13 +94,10 @@ Comma separated list of required configuration keys:
     file_base_name = String.slice(file_name, 0..-4)
 
     required_keys =
-      case Mix.Shell.IO.prompt(@long_msg) |> String.trim() do
-        "" ->
-          []
-
-        keys ->
-          keys_to_atom(keys, ",")
-      end
+      @long_msg
+      |> Mix.Shell.IO.prompt()
+      |> String.trim()
+      |> keys_to_atom(",")
 
     bindings = [
       gateway: name,
@@ -138,6 +135,10 @@ Comma separated list of required configuration keys:
     decorated_message = "#{message} [#{suggestion}]"
     response = Mix.Shell.IO.prompt(decorated_message) |> String.trim()
     if response == "", do: suggestion, else: response
+  end
+
+  defp keys_to_atom("", _splitter) do
+    []
   end
 
   defp keys_to_atom(key_list, splitter) when is_binary(key_list) do

--- a/lib/mix/new.ex
+++ b/lib/mix/new.ex
@@ -132,8 +132,11 @@ Comma separated list of required configuration keys:
   end
 
   defp prompt_with_suggestion(message, suggestion) do
-    decorated_message = "#{message} [#{suggestion}]"
-    response = Mix.Shell.IO.prompt(decorated_message) |> String.trim()
+    response =
+      "#{message} [#{suggestion}]"
+      |> Mix.Shell.IO.prompt()
+      |> String.trim()
+
     if response == "", do: suggestion, else: response
   end
 


### PR DESCRIPTION
This pull requests refactors some of the code in the generator.

The command `mix credo -a` showed a list of warnings, and some of them were in the `new.ex` file.

The resolved warnings:
```
┃ [F] → Function is too complex (CC is 11, max is 9).
┃       lib/mix/new.ex:50:7 #(Mix.Tasks.Gringotts.New.run)
┃ [F] → Pipe chain should start with a raw value.
┃       lib/mix/new.ex:139 #(Mix.Tasks.Gringotts.New.prompt_with_suggestion)
┃ [F] → Pipe chain should start with a raw value.
┃       lib/mix/new.ex:102 #(Mix.Tasks.Gringotts.New.run)
┃ [F] → Pipe chain should start with a raw value.
┃       lib/mix/new.ex:97 #(Mix.Tasks.Gringotts.New.run)
```

This pull request also fixes issue #158 