### PR TITLE
Remove broken Heroku demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  Gringotts is a payment processing library in Elixir integrating various payment gateways, drawing motivation from Shopify's <a href="https://github.com/activemerchant/active_merchant"><code>activemerchant</code></a> gem and <a href="https://github.com/joshnuss/commerce_billing"><code>commerce_billing</code></a>. Checkout the <a href="https://gringottspay.herokuapp.com/" target="_">demo here</a>.
+  Gringotts is a payment processing library in Elixir integrating various payment gateways, drawing motivation from Shopify's <a href="https://github.com/activemerchant/active_merchant"><code>activemerchant</code></a> gem and <a href="https://github.com/joshnuss/commerce_billing"><code>commerce_billing</code></a>.
 </p>
 <p align="center">
  <a href="https://travis-ci.org/aviabird/gringotts"><img src="https://travis-ci.org/aviabird/gringotts.svg?branch=master"  alt='Build Status' /></a>  <a href='https://coveralls.io/github/aviabird/gringotts?branch=master'><img src='https://coveralls.io/repos/github/aviabird/gringotts/badge.svg?branch=master' alt='Coverage Status' /></a> <a href="https://hex.pm/packages/gringotts"><img src="https://img.shields.io/hexpm/v/gringotts.svg"/></a> <a href="https://inch-ci.org/github/aviabird/gringotts"><img src="http://inch-ci.org/github/aviabird/gringotts.svg?branch=master" alt="Docs coverage"></img></a> <a href="https://gitter.im/aviabird/gringotts"><img src="https://badges.gitter.im/aviabird/gringotts.svg"/></a>
@@ -145,7 +145,6 @@ represent monies. You just have to add it in your `deps()`.
 [stripe]: https://www.stripe.com/
 [trexle]: https://www.trexle.com/
 [wirecard]: http://www.wirecard.com
-[demo]: https://gringottspay.herokuapp.com/
 
 ## [Road Map][roadmap]
 

--- a/lib/gringotts/gateways/cams.ex
+++ b/lib/gringotts/gateways/cams.ex
@@ -93,11 +93,10 @@ defmodule Gringotts.Gateways.Cams do
 
   ## Integrating with phoenix
 
-  Refer the [GringottsPay][gpay-heroku-cams] website for an example of how to
-  integrate CAMS with phoenix. The source is available [here][gpay-repo].
+  Refer the [GringottsPay][gpay-repo] source for an example of how to
+  integrate CAMS with phoenix.
 
   [gpay-repo]: https://github.com/aviabird/gringotts_payment
-  [gpay-heroku-cams]: http://gringottspay.herokuapp.com/cams
 
   ## TODO
 

--- a/test/documentation_test.exs
+++ b/test/documentation_test.exs
@@ -1,0 +1,14 @@
+defmodule DocumentationTest do
+  use ExUnit.Case
+
+  @readme_path Path.join([__DIR__, "..", "README.md"])
+
+  test "README should not contain broken Heroku demo link" do
+    readme_content = File.read!(@readme_path)
+
+    # The old Heroku demo at https://gringottspay.herokuapp.com is no longer active
+    # and should be removed from the README
+    refute String.contains?(readme_content, "gringottspay.herokuapp.com"),
+           "README contains broken Heroku demo link that should be removed"
+  end
+end


### PR DESCRIPTION
Fixes #191

## Summary

- The Heroku demo at `gringottspay.herokuapp.com` is no longer active (Heroku removed free dynos in Nov 2022). Removed the broken link from README.md and the CAMS gateway moduledoc.
- Kept the source repo reference at `aviabird/gringotts_payment` so users can still find the integration example.
- Added `test/documentation_test.exs` to prevent broken Heroku links from being reintroduced.

## Test plan

- [ ] `mix test test/documentation_test.exs` passes
- [ ] Verify no remaining references to `gringottspay.herokuapp.com` in codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated demo reference from README
  * Updated integration guide to reference correct documentation source

* **Tests**
  * Added automated validation to ensure documentation links remain current

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aviabird/gringotts/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->